### PR TITLE
Make pipeline reference optional for the token.

### DIFF
--- a/server/npg/porchdb/models/token.py
+++ b/server/npg/porchdb/models/token.py
@@ -44,8 +44,11 @@ class Token(Base):
     token_id = Column(Integer, primary_key=True, autoincrement=True)
     token = Column(String(length=32), unique=True, default=random_token)
     description = Column(String, nullable=False)
+    # Nullable foreign key into the pipeline table to accommodate
+    # admin tokens that are not linked to any particular pipeline.
+    # Example: endpoint for creating a new pipeline record.
     pipeline_id = Column(Integer, ForeignKey('pipeline.pipeline_id'),
-                         nullable=False)
+                         nullable=True)
     date_issued = Column(DateTime, default=sqlalchemy.sql.functions.now())
     date_revoked = Column(DateTime, nullable=True)
 

--- a/server/tests/db_token_test.py
+++ b/server/tests/db_token_test.py
@@ -11,10 +11,13 @@ async def test_token_creation(async_minimum):
         select(Token)
     )
     tokens = result.scalars().all()
-    assert len(tokens) == 2
+    assert len(tokens) == 3
     for t in tokens:
         assert t.token is not None
         assert len(t.token) == 32
         assert t.date_issued is not None
         assert t.date_revoked is None
-        assert t.pipeline.repository_uri == 'pipeline-test.com'
+        if t.description == 'Seqfarm host, admin':
+            assert t.pipeline is None
+        else:
+            assert t.pipeline.repository_uri == 'pipeline-test.com'

--- a/server/tests/fixtures/deploy_db.py
+++ b/server/tests/fixtures/deploy_db.py
@@ -19,16 +19,21 @@ def minimum_data():
         repository_uri='pipeline-test.com',
         version='0.3.14'
     )
-    job_finder_token = Token(
-        pipeline=pipeline,
-        description='OpenStack host, job finder'
-    )
-    job_runner_token = Token(
-        pipeline=pipeline,
-        description='Seqfarm host, job runner'
-    )
+    tokens = [
+        Token(
+            pipeline=pipeline,
+            description='OpenStack host, job finder'
+        ),
+        Token(
+            pipeline=pipeline,
+            description='Seqfarm host, job runner'
+        ),
+        Token(
+            description='Seqfarm host, admin'
+        )
+    ]
     b_event = a_event = Event(
-        token=job_finder_token,
+        token=tokens[0],
         change='Created'
     )
     tasks = [
@@ -52,10 +57,11 @@ def minimum_data():
             }
         )
     ]
-    entities = UserList(
-        [pipeline, job_finder_token, job_runner_token, b_event, a_event])
-    for t in tasks:
-        entities.append(t)
+
+    entities = UserList([pipeline, b_event, a_event])
+    entities.extend(tokens)
+    entities.extend(tasks)
+
     return entities
 
 


### PR DESCRIPTION
Nullable foreign key into the pipeline table to accommodate
admin tokens that are not linked to any particular pipeline.
Example: endpoint for creating a new pipeline record.