### PR TITLE
Newer starlette releases require httpx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         'pydantic',
         'pysqlite3',
         'psycopg2-binary',
+        'starlette>=0.22.0',
         'sqlalchemy>=1.4.29',
         'ujson',
         'uvicorn',
@@ -34,7 +35,8 @@ setup(
             'pytest',
             'pytest-asyncio',
             'requests',
-            'flake8'
+            'flake8',
+            'httpx'
         ]
     }
 )

--- a/tests/pipeline_route_test.py
+++ b/tests/pipeline_route_test.py
@@ -16,18 +16,18 @@ headers4power_user = {
 def http_create_pipeline(fastapi_testclient, pipeline):
 
     response = fastapi_testclient.post(
-        '/pipelines', json=pipeline.dict(), allow_redirects=True
+        '/pipelines', json=pipeline.dict(), follow_redirects=True
     )
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
     response = fastapi_testclient.post(
-        '/pipelines', json=pipeline.dict(), allow_redirects=True,
+        '/pipelines', json=pipeline.dict(), follow_redirects=True,
         headers=headers
     )
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
     response = fastapi_testclient.post(
-        '/pipelines', json=pipeline.dict(), allow_redirects=True,
+        '/pipelines', json=pipeline.dict(), follow_redirects=True,
         headers=headers4power_user
     )
     assert response.status_code == status.HTTP_201_CREATED
@@ -116,7 +116,7 @@ def test_create_pipeline(async_minimum, fastapi_testclient):
     response = fastapi_testclient.post(
         '/pipelines',
         json=desired_pipeline.dict(),
-        allow_redirects=True,
+        follow_redirects=True,
         headers=headers4power_user
     )
     assert response.status_code == status.HTTP_409_CONFLICT, 'ptest two already in DB'
@@ -148,7 +148,7 @@ def test_create_pipeline(async_minimum, fastapi_testclient):
     response = fastapi_testclient.post(
         '/pipelines',
         json=third_desired_pipeline.dict(),
-        allow_redirects=True,
+        follow_redirects=True,
         headers=headers4power_user
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/tests/task_route_test.py
+++ b/tests/task_route_test.py
@@ -28,7 +28,7 @@ def test_task_creation(async_minimum, fastapi_testclient):
     response = fastapi_testclient.post(
         'tasks',
         json=task_one.dict(),
-        allow_redirects=True,
+        follow_redirects=True,
         headers=headers4ptest_one
     )
     assert response.status_code == status.HTTP_201_CREATED
@@ -38,7 +38,7 @@ def test_task_creation(async_minimum, fastapi_testclient):
     response = fastapi_testclient.post(
         'tasks',
         json=task_one.dict(),
-        allow_redirects=True,
+        follow_redirects=True,
         headers=headers4ptest_one
     )
     assert response.status_code == status.HTTP_409_CONFLICT
@@ -56,7 +56,7 @@ def test_task_creation(async_minimum, fastapi_testclient):
     response = fastapi_testclient.post(
         'tasks',
         json=task_two.dict(),
-        allow_redirects=True,
+        follow_redirects=True,
         headers=headers4ptest_one
     )
     assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -71,7 +71,7 @@ def test_task_update(async_minimum, fastapi_testclient):
     response = fastapi_testclient.put(
         '/tasks',
         json=task,
-        allow_redirects=True,
+        follow_redirects=True,
         headers=headers4ptest_one
     )
     assert response.status_code == status.HTTP_200_OK
@@ -86,7 +86,7 @@ def test_task_update(async_minimum, fastapi_testclient):
     response = fastapi_testclient.put(
         '/tasks',
         json=modified_task.dict(),
-        allow_redirects=True,
+        follow_redirects=True,
         headers=headers4ptest_one
     )
     assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -101,7 +101,7 @@ def test_task_update(async_minimum, fastapi_testclient):
     response = fastapi_testclient.put(
         '/tasks',
         json=modified_task.dict(),
-        allow_redirects=True,
+        follow_redirects=True,
         headers=headers4ptest_one
     )
     assert response.status_code == status.HTTP_403_FORBIDDEN


### PR DESCRIPTION
and redirect handling has changed. Update and pin to starlette 0.22 or newer. httpx import required because starlette does not pull it in by default.