### PR TITLE
Fix pipelines endpoint to return HTTP 422 on bad input rather than 409

### DIFF
--- a/src/npg_porch/models/pipeline.py
+++ b/src/npg_porch/models/pipeline.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021, 2022 Genome Research Ltd.
+# Copyright (C) 2021, 2022, 2024 Genome Research Ltd.
 #
 # Author: Kieron Taylor kt19@sanger.ac.uk
 # Author: Marina Gourtovaia mg8@sanger.ac.uk
@@ -18,9 +18,11 @@
 # You should have received a copy of the GNU General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 class Pipeline(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
     name: str = Field(
         default = None,
         title='Pipeline Name',

--- a/tests/pipeline_route_test.py
+++ b/tests/pipeline_route_test.py
@@ -1,3 +1,5 @@
+import json
+
 from starlette import status
 
 from npg_porch.models import Pipeline
@@ -100,6 +102,16 @@ def test_get_known_pipeline(async_minimum, fastapi_testclient):
 
 
 def test_create_pipeline(async_minimum, fastapi_testclient):
+    invalid_pipeline = {
+        "name": "ptest one",
+        "url": "http://test.com",  # URL, not URI
+        "version": "1"
+    }
+    response = fastapi_testclient.post(
+            "/pipelines", json=json.dumps(invalid_pipeline), follow_redirects=True,
+            headers=headers4power_user
+    )
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
     # Create a pipeline
     desired_pipeline = Pipeline(


### PR DESCRIPTION
Add model validation to the Pydantic class to forbid extra fields. This prevents the endpoint returning that a pipeline already exists (409) when it fails to create a row in the database due to constraint violation (NULL because of a misspelled field).

Fixes #59 