### PR TITLE
Add Dependabot configuration for pip and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+- package-ecosystem: "pip"
+  directory: "/"
+  schedule:
+    interval: "daily"
+    time: "00:00"
+    timezone: "Europe/London"
+  open-pull-requests-limit: 5
+
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"
+    time: "00:00"
+    timezone: "Europe/London"
+  open-pull-requests-limit: 5


### PR DESCRIPTION
Dependabot has been very useful in helping keep up with bug fixes and CVEs.