### PR TITLE
Add UI with a simple paged table of tasks sorted by date of last change

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "aiosqlite",
     "asyncpg",
     "fastapi",
+    "jinja2",
     "pydantic > 2.0.0",
     "psycopg2-binary",
     "sqlalchemy >2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61"]
+requires = ["setuptools>=61", "setuptools-scm>8"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/src/npg_porch/db/data_access.py
+++ b/src/npg_porch/db/data_access.py
@@ -276,6 +276,8 @@ class AsyncDbAccessor:
 
         query = add_filters(query, filters)
 
+        self.logger.info(query)
+
         result = await self.session.execute(query)
         tasks = result.scalars().all()
         return [task.convert_to_model()for task in tasks]

--- a/src/npg_porch/db/data_access.py
+++ b/src/npg_porch/db/data_access.py
@@ -253,8 +253,7 @@ class AsyncDbAccessor:
     async def get_ordered_tasks(self,
                                 filters: dict,
                                 limit: int,
-                                page: int,
-                                date_range: tuple[datetime.date, datetime.date] | None = None,
+                                page: int
                                 ) -> list[TaskExpanded]:
         """
         Gets tasks in order of their most recent status change, with a provided

--- a/src/npg_porch/db/models/__init__.py
+++ b/src/npg_porch/db/models/__init__.py
@@ -1,5 +1,4 @@
 from .base import Base
 from .token import Token
 from .pipeline import Pipeline
-from .task import Task
-from .event import Event
+from .task import Task, TaskExpanded

--- a/src/npg_porch/db/models/__init__.py
+++ b/src/npg_porch/db/models/__init__.py
@@ -2,3 +2,4 @@ from .base import Base
 from .token import Token
 from .pipeline import Pipeline
 from .task import Task, TaskExpanded
+from .event import Event

--- a/src/npg_porch/db/models/event.py
+++ b/src/npg_porch/db/models/event.py
@@ -25,8 +25,8 @@ from sqlalchemy import (
 from sqlalchemy.orm import relationship
 
 from .base import Base
-from npg_porch.models import Event as ModelledEvent
 from .task import Task
+from npg_porch.models import Event as ModelledEvent
 
 class Event(Base):
     '''

--- a/src/npg_porch/db/models/event.py
+++ b/src/npg_porch/db/models/event.py
@@ -25,6 +25,8 @@ from sqlalchemy import (
 from sqlalchemy.orm import relationship
 
 from .base import Base
+from npg_porch.db.models.task import Task
+from npg_porch.models import Event as ModelledEvent
 
 class Event(Base):
     '''
@@ -33,7 +35,7 @@ class Event(Base):
     '''
     __tablename__ = 'event'
     event_id = Column(Integer, primary_key=True, autoincrement=True)
-    task_id = Column(Integer, ForeignKey('task.task_id'))
+    task_id = Column(Integer, ForeignKey(Task.task_id))
     time = Column(DateTime, default=sqlalchemy.sql.functions.now())
     change = Column(String)
     token_id = Column(Integer, ForeignKey('token.token_id'), nullable=False)
@@ -46,3 +48,9 @@ class Event(Base):
     token = relationship(
         'Token', back_populates='events'
     )
+
+    def convert_to_model(self):
+        return ModelledEvent(
+            time=self.time,
+            change=self.change
+        )

--- a/src/npg_porch/db/models/event.py
+++ b/src/npg_porch/db/models/event.py
@@ -25,8 +25,8 @@ from sqlalchemy import (
 from sqlalchemy.orm import relationship
 
 from .base import Base
-from npg_porch.db.models.task import Task
 from npg_porch.models import Event as ModelledEvent
+from .task import Task
 
 class Event(Base):
     '''

--- a/src/npg_porch/db/models/task.py
+++ b/src/npg_porch/db/models/task.py
@@ -77,6 +77,7 @@ class TaskExpanded(Task):
         return ModelledTaskExpanded(
             pipeline=self.pipeline.convert_to_model(),
             created=self.created,
+            task_input_id=self.job_descriptor,
             task_input=self.definition,
             status=self.state
         )

--- a/src/npg_porch/db/models/task.py
+++ b/src/npg_porch/db/models/task.py
@@ -27,6 +27,7 @@ from sqlalchemy.sql.sqltypes import DateTime
 
 from .base import Base
 from npg_porch.models import Task as ModelledTask
+from npg_porch.models import TaskExpanded as ModelledTaskExpanded
 
 
 class Task(Base):
@@ -66,6 +67,16 @@ class Task(Base):
         return ModelledTask(
             pipeline=self.pipeline.convert_to_model(),
             task_input_id=self.job_descriptor,
+            task_input=self.definition,
+            status=self.state
+        )
+
+
+class TaskExpanded(Task):
+    def convert_to_model(self) -> ModelledTaskExpanded:
+        return ModelledTaskExpanded(
+            pipeline=self.pipeline.convert_to_model(),
+            created=self.created,
             task_input=self.definition,
             status=self.state
         )

--- a/src/npg_porch/models/__init__.py
+++ b/src/npg_porch/models/__init__.py
@@ -1,2 +1,3 @@
 from .pipeline import Pipeline
 from .task import Task, TaskExpanded, TaskStateEnum
+from .event import Event

--- a/src/npg_porch/models/__init__.py
+++ b/src/npg_porch/models/__init__.py
@@ -1,2 +1,2 @@
 from .pipeline import Pipeline
-from .task import Task, TaskStateEnum
+from .task import Task, TaskExpanded, TaskStateEnum

--- a/src/npg_porch/models/event.py
+++ b/src/npg_porch/models/event.py
@@ -1,0 +1,48 @@
+# Copyright (C) 2025 Genome Research Ltd.
+#
+# Author: Michael Kubiak mk35@sanger.ac.uk
+#
+# This file is part of npg_porch
+#
+# npg_porch is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation; either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+from datetime import datetime
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class Event(BaseModel):
+    model_config = ConfigDict(extra='ignore')
+
+    time: datetime = Field(
+        default=None,
+        title="Event Time",
+        description="Timestamp of the event"
+    )
+    change: str | None = Field(
+        default=None,
+        title="Event Change",
+        description="The change that occurred during the event"
+    )
+
+    def __lt__(self, other):
+        return self.date < other.date
+
+    def __gt__(self, other):
+        return self.date > other.date
+
+    def __eq__(self, other):
+        if not isinstance(other, Event):
+            return False
+        # doesn't care about task, probably not a problem right now
+        return self.date == other.date and self.change == other.change

--- a/src/npg_porch/models/task.py
+++ b/src/npg_porch/models/task.py
@@ -24,8 +24,6 @@ import ujson
 from pydantic import BaseModel, Field, ValidationError
 
 from npg_porch.models.pipeline import Pipeline
-from npg_porch.models.event import Event
-
 
 
 class TaskStateEnum(str, Enum):

--- a/src/npg_porch/models/task.py
+++ b/src/npg_porch/models/task.py
@@ -17,13 +17,15 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
-
+from datetime import datetime
 from enum import Enum
 import hashlib
 import ujson
 from pydantic import BaseModel, Field, ValidationError
 
 from npg_porch.models.pipeline import Pipeline
+from npg_porch.models.event import Event
+
 
 class TaskStateEnum(str, Enum):
 
@@ -90,3 +92,22 @@ class Task(BaseModel):
             return True
 
         return False
+
+
+class TaskExpanded(Task):
+    # events: list[Event] = Field(
+    #     default=[],
+    #     title="Task Events",
+    #     description="List of all events (changes of status) that have occurred for this task",
+    # )
+    # updated: datetime = Field(
+    #     default=None,
+    #     title="Task Updated",
+    #     description="The timestamp of the most recent event for this task"
+    # )
+    created: datetime = Field(
+        default=None,
+        title="Task Created",
+        description="The timestamp of the creation of the task"
+    )
+

--- a/src/npg_porch/models/task.py
+++ b/src/npg_porch/models/task.py
@@ -27,6 +27,7 @@ from npg_porch.models.pipeline import Pipeline
 from npg_porch.models.event import Event
 
 
+
 class TaskStateEnum(str, Enum):
 
     def __str__(self):

--- a/src/npg_porch/models/task.py
+++ b/src/npg_porch/models/task.py
@@ -96,11 +96,6 @@ class Task(BaseModel):
 
 
 class TaskExpanded(Task):
-    # events: list[Event] = Field(
-    #     default=[],
-    #     title="Task Events",
-    #     description="List of all events (changes of status) that have occurred for this task",
-    # )
     # updated: datetime = Field(
     #     default=None,
     #     title="Task Updated",

--- a/src/npg_porch/server.py
+++ b/src/npg_porch/server.py
@@ -22,6 +22,7 @@ import asyncio
 from fastapi import FastAPI, Request, Depends
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
+from jinja2 import Environment, PackageLoader
 from npg_porch.db.connection import get_DbAccessor
 from npg_porch.db.models import Pipeline, Task
 
@@ -49,8 +50,8 @@ app = FastAPI(
 app.include_router(pipelines.router)
 app.include_router(tasks.router)
 
-templates = Jinja2Templates(directory="src/npg_porch/templates")
-
+env = Environment(loader=PackageLoader('npg_porch', 'templates'))
+templates = Jinja2Templates(env=env)
 
 @app.get(
     "/",
@@ -72,7 +73,7 @@ async def root(request: Request,
     max_page = max_page if max_page > min_page else min_page
     page = min_page if page < min_page \
         else max_page if page > max_page \
-        else page  # need to clamp page number
+        else page  # need to clamp page number between min_page and max_page
 
     task_response = await db_accessor.get_ordered_tasks(filters=filters,
                                                         limit=limit,

--- a/src/npg_porch/server.py
+++ b/src/npg_porch/server.py
@@ -22,7 +22,6 @@ import asyncio
 from fastapi import FastAPI, Request, Depends
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
-from npg_porch.db import data_access
 from npg_porch.db.connection import get_DbAccessor
 from npg_porch.db.models import Pipeline, Task
 

--- a/src/npg_porch/server.py
+++ b/src/npg_porch/server.py
@@ -61,9 +61,9 @@ templates = Jinja2Templates(directory="src/npg_porch/templates")
             "documentation."
 )
 async def root(request: Request,
-               pipeline_name=None,
+               limit: int = 20,
                page: int = 1,
-               limit: int = 2,
+               pipeline_name=None,
                status=None,
                db_accessor=Depends(get_DbAccessor)
                ) -> HTMLResponse:
@@ -72,9 +72,9 @@ async def root(request: Request,
     max_page = int(await db_accessor.count_tasks(filters)/limit)
     max_page = max_page if max_page > min_page else min_page
     page = min_page if page < min_page else max_page if page > max_page else page  # need to clamp page number
-    print(f"min page: {min_page}, max_page: {max_page}, page: {page}")
-    task_response = await db_accessor.get_ordered_tasks(pipeline_name=pipeline_name, page=page, status=status, limit=limit)
+
+    task_response = await db_accessor.get_ordered_tasks(filters=filters, limit=limit, page=page)
     event_response = [await db_accessor.get_events_for_task(task) for task in task_response]
 
     return templates.TemplateResponse("index.j2", {"request": request, "tasks": zip(task_response, event_response),
-                                                   "min_page": min_page, "max_page": max_page})
+                                                   "current_page": page, "max_page": max_page})

--- a/src/npg_porch/server.py
+++ b/src/npg_porch/server.py
@@ -59,8 +59,17 @@ templates = Jinja2Templates(directory="src/npg_porch/templates")
     summary="Web page with filterable table of tasks and links to OpenAPI "
             "documentation."
 )
-async def root(request: Request, pipeline_name=None, status=None, task_response=Depends(tasks.get_tasks)) -> HTMLResponse:
+async def root(request: Request,
+               pipeline_name=None,
+               status=None,
+               task_response=Depends(tasks.get_tasks)
+               ) -> HTMLResponse:
 
-    return templates.TemplateResponse("index.j2", {"request": request, "tasks": [{
-        "pipeline": "A", "version": "1.0", "input": {}, "status": "PENDING", "changed": "01/01/2025", "created": "01/01/2025"}],
-                                                   "task_response": task_response})
+    task_list = []
+    for task in task_response:
+        task_list.append({"pipeline": task.pipeline.name,
+                          "version": task.pipeline.version,
+                          "input": task.task_input,
+                          "status": task.status})
+
+    return templates.TemplateResponse("index.j2", {"request": request, "tasks": task_list})

--- a/src/npg_porch/server.py
+++ b/src/npg_porch/server.py
@@ -70,10 +70,18 @@ async def root(request: Request,
     min_page = 1
     max_page = int(await db_accessor.count_tasks(filters)/limit)
     max_page = max_page if max_page > min_page else min_page
-    page = min_page if page < min_page else max_page if page > max_page else page  # need to clamp page number
+    page = min_page if page < min_page \
+        else max_page if page > max_page \
+        else page  # need to clamp page number
 
-    task_response = await db_accessor.get_ordered_tasks(filters=filters, limit=limit, page=page)
-    event_response = [await db_accessor.get_events_for_task(task) for task in task_response]
+    task_response = await db_accessor.get_ordered_tasks(filters=filters,
+                                                        limit=limit,
+                                                        page=page)
+    event_response = [await db_accessor.get_events_for_task(task)
+                      for task in task_response]
 
-    return templates.TemplateResponse("index.j2", {"request": request, "tasks": zip(task_response, event_response),
-                                                   "current_page": page, "max_page": max_page})
+    return templates.TemplateResponse("index.j2", {
+        "request": request,
+        "tasks": zip(task_response, event_response),
+        "current_page": page, "max_page": max_page
+    })

--- a/src/npg_porch/templates/index.j2
+++ b/src/npg_porch/templates/index.j2
@@ -14,8 +14,8 @@
           <th scope="col">Pipeline Version</th>
           <th scope="col">Task Input</th>
           <th scope="col">Status</th>
-          <th scope="col">Date Changed</th>
-          <th scope="col">Date Created</th>
+          {#<th scope="col">Date Changed</th>
+          <th scope="col">Date Created</th>#}
         </tr>
       </thead>
       <tbody>
@@ -25,8 +25,8 @@
             <td>{{ task.version }}</td>
             <td>{{ task.input }}</td>
             <td>{{ task.status }}</td>
-            <td>{{ task.changed }}</td>
-            <td>{{ task.created }}</td>
+            {#<td>{{ task.changed }}</td>
+            <td>{{ task.created }}</td>#}
           </tr>
         {% endfor %}
       </tbody>

--- a/src/npg_porch/templates/index.j2
+++ b/src/npg_porch/templates/index.j2
@@ -14,8 +14,8 @@
           <th scope="col">Pipeline Version</th>
           <th scope="col">Task Input</th>
           <th scope="col">Status</th>
-          {#<th scope="col">Date Changed</th>
-          <th scope="col">Date Created</th>#}
+          <th scope="col">Date Changed</th>
+          <th scope="col">Date Created</th>
         </tr>
       </thead>
       <tbody>
@@ -25,8 +25,8 @@
             <td>{{ task.version }}</td>
             <td>{{ task.input }}</td>
             <td>{{ task.status }}</td>
-            {#<td>{{ task.changed }}</td>
-            <td>{{ task.created }}</td>#}
+            <td>{{ task.changed }}</td>
+            <td>{{ task.created }}</td>
           </tr>
         {% endfor %}
       </tbody>

--- a/src/npg_porch/templates/index.j2
+++ b/src/npg_porch/templates/index.j2
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Porch</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+  </head>
+  <body>
+    <table class="table">
+      <thead>
+        <tr>
+          <th scope="col">Pipeline Name</th>
+          <th scope="col">Pipeline Version</th>
+          <th scope="col">Task Input</th>
+          <th scope="col">Status</th>
+          <th scope="col">Date Changed</th>
+          <th scope="col">Date Created</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for task in tasks %}
+          <tr>
+            <td>{{ task.pipeline }}</td>
+            <td>{{ task.version }}</td>
+            <td>{{ task.input }}</td>
+            <td>{{ task.status }}</td>
+            <td>{{ task.changed }}</td>
+            <td>{{ task.created }}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    <div>{{ task_response }}</div>
+
+    <div class="container text-center">
+      <div class="row">
+        <div class="column"><a href="/docs">docs</a></div>
+        <div class="column"><a href="/redoc">redoc</a></div>
+        <div class="column"><a href="/api/v1/openapi.json">OpenAPI JSON Schema</a></div>
+      </div>
+  </body>
+</html>

--- a/src/npg_porch/templates/index.j2
+++ b/src/npg_porch/templates/index.j2
@@ -25,8 +25,8 @@
             <td>{{ task[0].pipeline.version }}</td>
             <td>{{ task[0].task_input }}</td>
             <td>{{ task[0].status }}</td>
-            <td>{{ task[1][0].time }}</td>
-            <td>{{ task[0].created }}</td>
+            <td>{{ task[1][0].time.strftime('%d/%m/%y %H:%M:%S') }}</td>
+            <td>{{ task[0].created.strftime('%d/%m/%y %H:%M:%S') }}</td>
           </tr>
         {% endfor %}
       </tbody>

--- a/src/npg_porch/templates/index.j2
+++ b/src/npg_porch/templates/index.j2
@@ -34,8 +34,10 @@
 
     <div class="container text-center">
       <div class="row">
-        <div class="column"><a href="?page={{ min_page }}> {{ min_page }} </a></div>
-        <div class="column"><a href="?page={{ max_page }}> {{ max_page }} </a></div>
+        <div class="column"><a href="?page={{ min_page }}"> {{ min_page }} </a></div>
+        {% if max_page > min_page %}
+          <div class="column"><a href="?page={{ max_page }}"> {{ max_page }} </a></div>
+        {% endif %}
         <div class="column"><a href="/docs">docs</a></div>
         <div class="column"><a href="/redoc">redoc</a></div>
         <div class="column"><a href="/api/v1/openapi.json">OpenAPI JSON Schema</a></div>

--- a/src/npg_porch/templates/index.j2
+++ b/src/npg_porch/templates/index.j2
@@ -31,16 +31,54 @@
         {% endfor %}
       </tbody>
     </table>
+    {% if max_page > 1 %}
+      <nav aria-label="Pagination">
+        <ul class="pagination">
+          {% if current_page == 1 %}
+            <li class="page-item disabled">
+              <a class="page-link" href="?page={{ current_page-1 }}" aria-label="Previous">
+                <span area-hidden="true">&lt</span>
+              </a>
+            </li>
+          {% else %}
+            <li class="page-item">
+              <a class="page-link" href="?page={{ current_page-1 }}" aria-label="Previous">
+                <span area-hidden="true">&lt</span>
+              </a>
+            </li>
+          {% endif %}
+          {% for p in range(1, max_page + 1) %}
+            {% if p == current_page %}
+              <li class="page-item active" aria-current="page">
+                <a class="page-link" href="?page={{ p }}"> {{ p }} </a>
+              </li>
+            {% else %}
+              <li class="page-item">
+                <a class="page-link" href="?page={{ p }}"> {{ p }} </a>
+              </li>
+            {% endif %}
+          {% endfor %}
+          {% if current_page == max_page %}
+            <li class="page-item disabled">
+              <a class="page-link" href="?page={{ current_page+1 }}" aria-label="Next">
+                <span area-hidden="true">&gt</span>
+              </a>
+            </li>
+          {% else %}
+            <li class="page-item">
+              <a class="page-link" href="?page={{ current_page+1 }}" aria-label="Next">
+                <span area-hidden="true">&gt</span>
+              </a>
+            </li>
+          {% endif %}
+        </ul>
+      </nav>
+    {% endif %}
 
-    <div class="container text-center">
-      <div class="row">
-        <div class="column"><a href="?page={{ min_page }}"> {{ min_page }} </a></div>
-        {% if max_page > min_page %}
-          <div class="column"><a href="?page={{ max_page }}"> {{ max_page }} </a></div>
-        {% endif %}
-        <div class="column"><a href="/docs">docs</a></div>
-        <div class="column"><a href="/redoc">redoc</a></div>
-        <div class="column"><a href="/api/v1/openapi.json">OpenAPI JSON Schema</a></div>
-      </div>
+    <nav class="nav flex-column">
+      <a class="nav-link" href="/docs">docs</a>
+      <a class="nav-link" href="/redoc">redoc</a>
+      <a class="nav-link" href="/api/v1/openapi.json">OpenAPI JSON Schema</a>
+    </nav>
   </body>
 </html>

--- a/src/npg_porch/templates/index.j2
+++ b/src/npg_porch/templates/index.j2
@@ -21,20 +21,21 @@
       <tbody>
         {% for task in tasks %}
           <tr>
-            <td>{{ task.pipeline }}</td>
-            <td>{{ task.version }}</td>
-            <td>{{ task.input }}</td>
-            <td>{{ task.status }}</td>
-            <td>{{ task.changed }}</td>
-            <td>{{ task.created }}</td>
+            <td>{{ task[0].pipeline.name }}</td>
+            <td>{{ task[0].pipeline.version }}</td>
+            <td>{{ task[0].task_input }}</td>
+            <td>{{ task[0].status }}</td>
+            <td>{{ task[1][0].time }}</td>
+            <td>{{ task[0].created }}</td>
           </tr>
         {% endfor %}
       </tbody>
     </table>
-    <div>{{ task_response }}</div>
 
     <div class="container text-center">
       <div class="row">
+        <div class="column"><a href="?page={{ min_page }}> {{ min_page }} </a></div>
+        <div class="column"><a href="?page={{ max_page }}> {{ max_page }} </a></div>
         <div class="column"><a href="/docs">docs</a></div>
         <div class="column"><a href="/redoc">redoc</a></div>
         <div class="column"><a href="/api/v1/openapi.json">OpenAPI JSON Schema</a></div>


### PR DESCRIPTION
Can be partially filtered through the url.

I was hoping to get latest update date through the same query, but couldn't get it to work alongside getting the model.  We will need the extra information from the other query eventually anyway, but I was hoping to delay getting it until the user requested it.