### PR TITLE
Allow multiple versions per pipeline by adding a new version table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+
+* Separate version table, allowing multiple versions per pipeline.
+
 ### Changed
 
 * Exclude failed tasks from Long Running view.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npg_porch does:
 
 ## Requirements
 
-Python >= 3.7
+Python >= 3.10
 sqlite3 >= 3.9
 
 ## Installation & Usage
@@ -43,7 +43,7 @@ export DB_SCHEMA='non_default'
 uvicorn npg_porch.server:app --host 0.0.0.0 --port 8080 --reload --log-config logging.json
 ```
 
-and open your browser at `http://localhost:8080` to see links to the docs.
+and open your browser at `http://localhost:8080` to see the task listing.
 
 On macOS you will need to ensure that a version of the `sqlite3` library that supports SQLite extensions
 is used when installing the `pysqlite3` package. The system library on macOS does not, so an alternative

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,6 +1,6 @@
 
 ARG BASE_IMAGE=python:3.10-slim
-FROM $BASE_IMAGE as builder
+FROM $BASE_IMAGE AS builder
 
 ARG DEBIAN_FRONTEND="noninteractive"
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -53,10 +53,10 @@ You can name your pipeline however you like, but the name must be unique, and be
 **pipeline-def.json**
 
 ```javascript
-{
+{   
+    "version": "1.0"
     "name": "My First Pipeline",
     "uri": "https://github.com/wtsi-npg/my-special-pipeline",
-    "version": "1.0"
 }
 ```
 
@@ -79,9 +79,9 @@ We might create a cronjob that runs a script. It invokes `imeta` and retrieves a
 ```javascript
 {
     "pipeline": {
+        "version": "1.0",
         "name": "My First Pipeline",
         "uri": "https://github.com/wtsi-npg/my-special-pipeline",
-        "version": "1.0"
     },
     "task_input": {
         "study_id": 100,
@@ -103,7 +103,7 @@ Like any dictionary or Perl hash, order does not matter. The previous document i
     "pipeline": {
         "name": "My First Pipeline",
         "uri": "https://github.com/wtsi-npg/my-special-pipeline",
-        "version": "1.0"
+        "version": "1.0",
     }
 }
 ```
@@ -123,7 +123,11 @@ However, any change in the number or name of keys as well as the values is diffe
 
 Try to limit the content to the variable parts of pipeline configuration. Settings like `type="CRAM"` might be better as static arguments to the pipeline, rather than part of the definition here.
 
-Note that it is possible to run the same `task_input` with a different `pipeline`. For example, if a task failed, you might release a pipeline update. In order to run the same task again, you would need to register another pipeline and register the same task definition with the new pipeline. We do not currently support updating a pipeline with a new version.
+Note that it is possible to run the same `task_input` with a different `pipeline` or `version`. For example, if a task failed, you might release a new pipeline version. In order to run the same task again, you would need to register another version to the pipeline and register the same task definition with the new pipeline.
+
+A new version of a pipeline can be registered using the same json format as is used for registering a pipeline. A pipeline token is required.
+
+`url='https://$SERVER:$PORT/versions'; curl -L -XPOST ${url} -H "content-type: application/json" -H "Authorization: Bearer $PIPELINE_TOKEN" -w " %{http_code}" -d @pipeline-def.json`
 
 ### Step 3 - register the documents with npg_porch
 
@@ -183,7 +187,7 @@ if ($response->is_success) {
 
 Once a task has been submitted, and a 201 CREATED response has been received, the npg_porch server assigns a timestamp to the task, gives it a status of `PENDING` and assigns a unique ID to it. The response from the server contains this extra information.
 
-A 200 OK response means that this particular task for this pipeline has already been registered. The current representation of the task is returned, the status of the task might be different from `PENDING`.  Note that if there are many tasks to register, some of which were submitted previously, further work is required to make the process efficient - such as to ask the npg_porch server for a list of previously registered tasks for this pipeline.
+A 200 OK response means that this particular task for this pipeline version has already been registered. The current representation of the task is returned, the status of the task might be different from `PENDING`.  Note that if there are many tasks to register, some of which were submitted previously, further work is required to make the process efficient - such as to ask the npg_porch server for a list of previously registered tasks for this pipeline.
 
 ### Step 4 - write a script or program that can launch the pipeline
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = {file = "LICENSE.md"}
 dependencies = [
     "aiosqlite",
     "asyncpg",
-    "fastapi",
+    "fastapi >= 0.122.0",
     "jinja2",
     "pydantic > 2.0.0",
     "psycopg2-binary",

--- a/src/npg_porch/db/data_access.py
+++ b/src/npg_porch/db/data_access.py
@@ -95,6 +95,23 @@ class AsyncDbAccessor:
         version_result = await self.session.execute(query)
         return version_result.scalars().all()
 
+    async def _get_version_db_object(
+        self,
+        name: str,
+        version: str,
+    ):
+        version_result = await self.session.execute(
+            (
+                select(DbVersion)
+                .join(DbVersion.pipeline)
+                .options(joinedload(DbVersion.pipeline))
+            )
+            .filter(DbPipeline.name == name)
+            .filter(DbVersion.version == version)
+        )
+
+        return version_result.scalar_one()
+
     async def get_all_pipelines(self, uri: str | None = None) -> list[Pipeline]:
         pipelines = await self._get_pipeline_db_objects(uri=uri)
         return [pipe.convert_to_model() for pipe in pipelines]
@@ -121,15 +138,20 @@ class AsyncDbAccessor:
         assert isinstance(pipeline, Pipeline)
 
         pipe = DbPipeline(name=pipeline.name, repository_uri=pipeline.uri)
-
+        ver = DbVersion(version=pipeline.version, pipeline=pipe)
         session.add(pipe)
+        session.add(ver)
         await session.commit()
-        return pipe.convert_to_model()
+        return ver.convert_to_api_pipeline()
 
     async def create_version(self, pipeline: Pipeline) -> Pipeline:
         session = self.session
         assert isinstance(pipeline, Pipeline)
 
+        try:
+            await self._get_pipeline_db_object(pipeline.name)
+        except NoResultFound:
+            raise NoResultFound("Pipeline not found")
         ver = DbVersion(
             pipeline=DbPipeline(name=pipeline.name, repository_uri=pipeline.uri),
             version=pipeline.version,
@@ -160,10 +182,12 @@ class AsyncDbAccessor:
         """
         self.logger.debug("CREATE TASK: " + str(task))
         session = self.session
-        db_pipeline = await self._get_pipeline_db_object(task.pipeline.name)
+        db_version = await self._get_version_db_object(
+            version=task.pipeline.version, name=task.pipeline.name
+        )
 
         task.status = TaskStateEnum.PENDING
-        t = self.convert_task_to_db(task, db_pipeline)
+        t = self.convert_task_to_db(task, db_version)
         created = True
         try:
             nested = await session.begin_nested()
@@ -176,11 +200,13 @@ class AsyncDbAccessor:
             # Task already exists, query the database to get the up-to-date
             # representation of the task.
             t = await self.get_db_task(
-                pipeline_name=task.pipeline.name, job_descriptor=t.job_descriptor
+                pipeline_name=task.pipeline.name,
+                version=task.version.version,
+                job_descriptor=t.job_descriptor,
             )
             created = False
 
-        return (t.convert_to_model(), created)
+        return t.convert_to_model(), created
 
     async def claim_tasks(
         self, token_id: int, pipeline: Pipeline, claim_limit: int | None = 1
@@ -188,20 +214,20 @@ class AsyncDbAccessor:
         session = self.session
 
         try:
-            pipeline_result = await session.execute(
-                select(DbPipeline).filter_by(name=pipeline.name)
+            version = await self._get_version_db_object(
+                name=pipeline.name, version=pipeline.version
             )
-            pipeline = pipeline_result.scalar_one()
         except NoResultFound:
             raise NoResultFound("Pipeline not found")
 
         potential_tasks = await session.execute(
             select(DbTask)
-            .join(DbTask.pipeline)
-            .where(DbPipeline.name == pipeline.name)
+            .join(DbTask.version)
+            .join(DbVersion.pipeline)
+            .where(DbVersion.version_id == version.version_id)
             .where(DbTask.state == TaskStateEnum.PENDING)
             .order_by(DbTask.created)
-            .options(contains_eager(DbTask.pipeline))
+            .options(contains_eager(DbTask.version, DbVersion.pipeline))
             .with_for_update()
             .limit(claim_limit)
             .execution_options(populate_existing=True)
@@ -231,15 +257,18 @@ class AsyncDbAccessor:
         """
         session = self.session
         # Get the matching task from the DB
+        # TODO: This seems inefficient, think about later
         try:
-            db_pipe = await self._get_pipeline_db_object(task.pipeline.name)
+            db_ver = await self._get_version_db_object(
+                name=task.pipeline.name, version=task.pipeline.version
+            )
         except NoResultFound:
             raise NoResultFound("Pipeline not found")
 
         try:
             task_result = await session.execute(
                 select(DbTask)
-                .filter_by(pipeline=db_pipe)
+                .filter_by(version=db_ver)
                 .filter_by(job_descriptor=task.generate_task_id())
             )
             og_task = task_result.scalar_one()  # Doesn't raise exception if no rows?!
@@ -261,7 +290,10 @@ class AsyncDbAccessor:
         return og_task.convert_to_model()
 
     async def get_tasks(
-        self, pipeline_name: str | None = None, task_status: TaskStateEnum | None = None
+        self,
+        pipeline_name: str | None = None,
+        task_status: TaskStateEnum | None = None,
+        version: str | None = None,
     ) -> list[Task]:
         """
         Gets all the tasks.
@@ -269,7 +301,10 @@ class AsyncDbAccessor:
         Can filter tasks by pipeline name and task status in order to be more useful.
         """
         query = (
-            select(DbTask).join(DbTask.pipeline).options(joinedload(DbTask.pipeline))
+            select(DbTask)
+            .join(DbTask.version)
+            .join(DbVersion.pipeline)
+            .options(joinedload(DbTask.version, DbVersion.pipeline))
         )
 
         if pipeline_name:
@@ -277,6 +312,9 @@ class AsyncDbAccessor:
 
         if task_status:
             query = query.filter(DbTask.state == task_status)
+
+        if version:
+            query = query.filter(DbVersion.version == version)
 
         task_result = await self.session.execute(query)
         tasks = task_result.scalars().all()
@@ -287,6 +325,7 @@ class AsyncDbAccessor:
         pipeline_name: str = None,
         status: list[TaskStateEnum] = None,
         since: datetime = None,
+        version: str = None,
     ) -> list[TaskExpanded]:
         """
         Gets information about tasks including their creation date, ordered
@@ -304,8 +343,9 @@ class AsyncDbAccessor:
             select(DbTask, latest_event.c.status_date)
             .select_from(DbTask)
             .join(latest_event, DbTask.task_id == latest_event.c.task_id)
-            .join(DbTask.pipeline)
-            .options(contains_eager(DbTask.pipeline))
+            .join(DbTask.version)
+            .join(DbVersion.pipeline)
+            .options(contains_eager(DbTask.version, DbVersion.pipeline))
             .order_by(latest_event.c.status_date.desc())
         )
 
@@ -315,6 +355,8 @@ class AsyncDbAccessor:
             query = query.where(or_(DbTask.state == state for state in status))
         if since:
             query = query.where(latest_event.c.status_date >= since)
+        if version:
+            query = query.where(DbVersion.version == version)
 
         self.logger.debug(query.compile())
         task_result = await self.session.execute(query)
@@ -359,13 +401,16 @@ class AsyncDbAccessor:
         self,
         pipeline_name: str,
         job_descriptor: str,
+        version: str,
     ) -> DbTask:
         """Get the task."""
         query = (
             select(DbTask)
-            .join(DbTask.pipeline)
-            .options(joinedload(DbTask.pipeline))
+            .join(DbTask.version)
+            .join(DbVersion.pipeline)
+            .options(joinedload(DbTask.version, DbVersion.pipeline))
             .where(DbPipeline.name == pipeline_name)
+            .where(DbVersion.version == version)
             .where(DbTask.job_descriptor == job_descriptor)
         )
         task_result = await self.session.execute(query)
@@ -373,11 +418,11 @@ class AsyncDbAccessor:
         return task_result.scalars().one()
 
     @staticmethod
-    def convert_task_to_db(task: Task, pipeline: DbPipeline) -> DbTask:
+    def convert_task_to_db(task: Task, version: DbVersion) -> DbTask:
         assert task.status in TaskStateEnum
 
         return DbTask(
-            pipeline=pipeline,
+            version=version,
             job_descriptor=task.generate_task_id(),
             definition=task.task_input,
             state=task.status,

--- a/src/npg_porch/db/data_access.py
+++ b/src/npg_porch/db/data_access.py
@@ -119,7 +119,7 @@ class AsyncDbAccessor:
     async def get_pipeline_versions(
         self, pipeline_name: str | None = None
     ) -> list[str]:
-        versions = self._get_pipeline_version_db_objects(name=pipeline_name)
+        versions = await self._get_pipeline_version_db_objects(name=pipeline_name)
         return [version.version for version in versions]
 
     async def get_recent_pipelines(self):
@@ -149,11 +149,11 @@ class AsyncDbAccessor:
         assert isinstance(pipeline, Pipeline)
 
         try:
-            await self._get_pipeline_db_object(pipeline.name)
+            pipe = await self._get_pipeline_db_object(pipeline.name)
         except NoResultFound:
             raise NoResultFound("Pipeline not found")
         ver = DbVersion(
-            pipeline=DbPipeline(name=pipeline.name, repository_uri=pipeline.uri),
+            pipeline=pipe,
             version=pipeline.version,
         )
 
@@ -201,7 +201,7 @@ class AsyncDbAccessor:
             # representation of the task.
             t = await self.get_db_task(
                 pipeline_name=task.pipeline.name,
-                version=task.version.version,
+                version=task.pipeline.version,
                 job_descriptor=t.job_descriptor,
             )
             created = False

--- a/src/npg_porch/db/data_access.py
+++ b/src/npg_porch/db/data_access.py
@@ -28,6 +28,7 @@ from sqlalchemy.orm import contains_eager, joinedload
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.sql.functions import count, max as samax
 
+from npg_porch.db.exceptions import IncompatibleArgumentsException
 from npg_porch.db.models import Event
 from npg_porch.db.models import Pipeline as DbPipeline
 from npg_porch.db.models import Version as DbVersion
@@ -299,7 +300,7 @@ class AsyncDbAccessor:
         Can filter tasks by pipeline name, task status and version in order to be more useful.
         """
         if version and not pipeline_name:
-            raise Exception(
+            raise IncompatibleArgumentsException(
                 "A version without a pipeline name is not meaningful when getting tasks"
             )
         query = (
@@ -336,7 +337,7 @@ class AsyncDbAccessor:
         Can be filtered by pipeline name and status.
         """
         if version and not pipeline_name:
-            raise Exception(
+            raise IncompatibleArgumentsException(
                 "A version without a pipeline name is not meaningful when getting tasks"
             )
         latest_event = (

--- a/src/npg_porch/db/data_access.py
+++ b/src/npg_porch/db/data_access.py
@@ -30,6 +30,7 @@ from sqlalchemy.sql.functions import count, max as samax
 
 from npg_porch.db.models import Event
 from npg_porch.db.models import Pipeline as DbPipeline
+from npg_porch.db.models import Version as DbVersion
 from npg_porch.db.models import Task as DbTask
 from npg_porch.db.models import Token as DbToken
 from npg_porch.models import Pipeline, Task, TaskStateEnum, TaskExpanded
@@ -62,10 +63,28 @@ class AsyncDbAccessor:
     async def _get_pipeline_db_objects(
         self,
         name: str | None = None,
-        version: str | None = None,
         uri: str | None = None,
     ) -> list[Pipeline]:
         query = select(DbPipeline)
+        if name:
+            query = query.filter_by(name=name)
+        if uri:
+            query = query.filter_by(repository_uri=uri)
+
+        pipeline_result = await self.session.execute(query)
+        return pipeline_result.scalars().all()
+
+    async def _get_pipeline_version_db_objects(
+        self,
+        name: str | None = None,
+        version: str | None = None,
+        uri: str | None = None,
+    ):
+        query = (
+            select(DbVersion)
+            .join(DbVersion.pipeline)
+            .options(joinedload(DbVersion.pipeline))
+        )
         if name:
             query = query.filter_by(name=name)
         if version:
@@ -73,14 +92,18 @@ class AsyncDbAccessor:
         if uri:
             query = query.filter_by(repository_uri=uri)
 
-        pipeline_result = await self.session.execute(query)
-        return pipeline_result.scalars().all()
+        version_result = await self.session.execute(query)
+        return version_result.scalars().all()
 
-    async def get_all_pipelines(
-        self, uri: str | None = None, version: str | None = None
-    ) -> list[Pipeline]:
-        pipelines = await self._get_pipeline_db_objects(uri=uri, version=version)
+    async def get_all_pipelines(self, uri: str | None = None) -> list[Pipeline]:
+        pipelines = await self._get_pipeline_db_objects(uri=uri)
         return [pipe.convert_to_model() for pipe in pipelines]
+
+    async def get_pipeline_versions(
+        self, pipeline_name: str | None = None
+    ) -> list[str]:
+        versions = self._get_pipeline_version_db_objects(name=pipeline_name)
+        return [version.version for version in versions]
 
     async def get_recent_pipelines(self):
         query = (
@@ -97,13 +120,24 @@ class AsyncDbAccessor:
         session = self.session
         assert isinstance(pipeline, Pipeline)
 
-        pipe = DbPipeline(
-            name=pipeline.name, version=pipeline.version, repository_uri=pipeline.uri
-        )
+        pipe = DbPipeline(name=pipeline.name, repository_uri=pipeline.uri)
 
         session.add(pipe)
         await session.commit()
         return pipe.convert_to_model()
+
+    async def create_version(self, pipeline: Pipeline) -> Pipeline:
+        session = self.session
+        assert isinstance(pipeline, Pipeline)
+
+        ver = DbVersion(
+            pipeline=DbPipeline(name=pipeline.name, repository_uri=pipeline.uri),
+            version=pipeline.version,
+        )
+
+        session.add(ver)
+        await session.commit()
+        return ver.convert_to_api_pipeline()
 
     async def create_pipeline_token(self, name: str, desc: str) -> Token:
         session = self.session

--- a/src/npg_porch/db/data_access.py
+++ b/src/npg_porch/db/data_access.py
@@ -298,23 +298,23 @@ class AsyncDbAccessor:
         """
         Gets all the tasks.
 
-        Can filter tasks by pipeline name and task status in order to be more useful.
+        Can filter tasks by pipeline name, task status and version in order to be more useful.
         """
         query = (
             select(DbTask)
             .join(DbTask.version)
             .join(DbVersion.pipeline)
-            .options(joinedload(DbTask.version, DbVersion.pipeline))
+            .options(contains_eager(DbTask.version, DbVersion.pipeline))
         )
 
         if pipeline_name:
             query = query.where(DbPipeline.name == pipeline_name)
 
         if task_status:
-            query = query.filter(DbTask.state == task_status)
+            query = query.where(DbTask.state == task_status)
 
         if version:
-            query = query.filter(DbVersion.version == version)
+            query = query.where(DbVersion.version == version)
 
         task_result = await self.session.execute(query)
         tasks = task_result.scalars().all()

--- a/src/npg_porch/db/data_access.py
+++ b/src/npg_porch/db/data_access.py
@@ -116,9 +116,7 @@ class AsyncDbAccessor:
         pipelines = await self._get_pipeline_db_objects(uri=uri)
         return [pipe.convert_to_model() for pipe in pipelines]
 
-    async def get_pipeline_versions(
-        self, pipeline_name: str | None = None
-    ) -> list[str]:
+    async def get_pipeline_versions(self, pipeline_name: str) -> list[str]:
         versions = await self._get_pipeline_version_db_objects(name=pipeline_name)
         return [version.version for version in versions]
 
@@ -135,18 +133,19 @@ class AsyncDbAccessor:
 
     async def create_pipeline(self, pipeline: Pipeline) -> Pipeline:
         session = self.session
-        assert isinstance(pipeline, Pipeline)
+        if not isinstance(pipeline, Pipeline):
+            raise TypeError
 
         pipe = DbPipeline(name=pipeline.name, repository_uri=pipeline.uri)
         ver = DbVersion(version=pipeline.version, pipeline=pipe)
-        session.add(pipe)
         session.add(ver)
         await session.commit()
         return ver.convert_to_api_pipeline()
 
     async def create_version(self, pipeline: Pipeline) -> Pipeline:
         session = self.session
-        assert isinstance(pipeline, Pipeline)
+        if not isinstance(pipeline, Pipeline):
+            raise TypeError
 
         try:
             pipe = await self._get_pipeline_db_object(pipeline.name)
@@ -222,12 +221,12 @@ class AsyncDbAccessor:
 
         potential_tasks = await session.execute(
             select(DbTask)
-            .join(DbTask.version)
+            .join(DbTask.pipeline_version)
             .join(DbVersion.pipeline)
             .where(DbVersion.version_id == version.version_id)
             .where(DbTask.state == TaskStateEnum.PENDING)
             .order_by(DbTask.created)
-            .options(contains_eager(DbTask.version, DbVersion.pipeline))
+            .options(contains_eager(DbTask.pipeline_version, DbVersion.pipeline))
             .with_for_update()
             .limit(claim_limit)
             .execution_options(populate_existing=True)
@@ -257,7 +256,6 @@ class AsyncDbAccessor:
         """
         session = self.session
         # Get the matching task from the DB
-        # TODO: This seems inefficient, think about later
         try:
             db_ver = await self._get_version_db_object(
                 name=task.pipeline.name, version=task.pipeline.version
@@ -268,7 +266,7 @@ class AsyncDbAccessor:
         try:
             task_result = await session.execute(
                 select(DbTask)
-                .filter_by(version=db_ver)
+                .filter_by(pipeline_version=db_ver)
                 .filter_by(job_descriptor=task.generate_task_id())
             )
             og_task = task_result.scalar_one()  # Doesn't raise exception if no rows?!
@@ -300,11 +298,15 @@ class AsyncDbAccessor:
 
         Can filter tasks by pipeline name, task status and version in order to be more useful.
         """
+        if version and not pipeline_name:
+            raise Exception(
+                "A version without a pipeline name is not meaningful when getting tasks"
+            )
         query = (
             select(DbTask)
-            .join(DbTask.version)
+            .join(DbTask.pipeline_version)
             .join(DbVersion.pipeline)
-            .options(contains_eager(DbTask.version, DbVersion.pipeline))
+            .options(contains_eager(DbTask.pipeline_version, DbVersion.pipeline))
         )
 
         if pipeline_name:
@@ -333,6 +335,10 @@ class AsyncDbAccessor:
 
         Can be filtered by pipeline name and status.
         """
+        if version and not pipeline_name:
+            raise Exception(
+                "A version without a pipeline name is not meaningful when getting tasks"
+            )
         latest_event = (
             select(samax(Event.time).label("status_date"), Event.task_id)
             .select_from(Event)
@@ -343,9 +349,9 @@ class AsyncDbAccessor:
             select(DbTask, latest_event.c.status_date)
             .select_from(DbTask)
             .join(latest_event, DbTask.task_id == latest_event.c.task_id)
-            .join(DbTask.version)
+            .join(DbTask.pipeline_version)
             .join(DbVersion.pipeline)
-            .options(contains_eager(DbTask.version, DbVersion.pipeline))
+            .options(contains_eager(DbTask.pipeline_version, DbVersion.pipeline))
             .order_by(latest_event.c.status_date.desc())
         )
 
@@ -406,9 +412,9 @@ class AsyncDbAccessor:
         """Get the task."""
         query = (
             select(DbTask)
-            .join(DbTask.version)
+            .join(DbTask.pipeline_version)
             .join(DbVersion.pipeline)
-            .options(joinedload(DbTask.version, DbVersion.pipeline))
+            .options(joinedload(DbTask.pipeline_version, DbVersion.pipeline))
             .where(DbPipeline.name == pipeline_name)
             .where(DbVersion.version == version)
             .where(DbTask.job_descriptor == job_descriptor)
@@ -419,10 +425,11 @@ class AsyncDbAccessor:
 
     @staticmethod
     def convert_task_to_db(task: Task, version: DbVersion) -> DbTask:
-        assert task.status in TaskStateEnum
+        if task.status not in TaskStateEnum:
+            raise ValueError
 
         return DbTask(
-            version=version,
+            pipeline_version=version,
             job_descriptor=task.generate_task_id(),
             definition=task.task_input,
             state=task.status,

--- a/src/npg_porch/db/exceptions.py
+++ b/src/npg_porch/db/exceptions.py
@@ -1,0 +1,22 @@
+# Copyright (C) 2026 Genome Research Ltd.
+#
+# Author: Michael Kubiak mk35@sanger.ac.uk
+#
+# This file is part of npg_porch
+#
+# npg_porch is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation; either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+class IncompatibleArgumentsException(Exception):
+    pass

--- a/src/npg_porch/db/models/__init__.py
+++ b/src/npg_porch/db/models/__init__.py
@@ -3,3 +3,4 @@ from .token import Token
 from .pipeline import Pipeline
 from .task import Task
 from .event import Event
+from .version import Version

--- a/src/npg_porch/db/models/pipeline.py
+++ b/src/npg_porch/db/models/pipeline.py
@@ -35,14 +35,10 @@ class Pipeline(Base):
     pipeline_id = Column(Integer, primary_key=True, autoincrement=True)
     name = Column(String, unique=True, nullable=False)
     repository_uri = Column(String, nullable=False)
-    version = Column(String, nullable=False)
 
-    tasks = relationship("Task", back_populates="pipeline")
-
+    versions = relationship("Version", back_populates="pipeline")
     tokens = relationship("Token", back_populates="pipeline")
 
     def convert_to_model(self):
         "Convert sqlalchemy object to npg_porch format"
-        return ModeledPipeline(
-            name=self.name, version=self.version, uri=self.repository_uri
-        )
+        return ModeledPipeline(name=self.name, uri=self.repository_uri)

--- a/src/npg_porch/db/models/task.py
+++ b/src/npg_porch/db/models/task.py
@@ -43,7 +43,7 @@ class Task(Base):
 
     __tablename__ = "task"
     task_id = Column(Integer, primary_key=True, autoincrement=True)
-    pipeline_id = Column(Integer, ForeignKey("pipeline.pipeline_id"))
+    version_id = Column(Integer, ForeignKey("version.version_id"))
     job_descriptor = Column(String)
     # This is the serialisation of Dict representing the JSON
     # provided by the workflow - we don't want to get into serialising
@@ -59,13 +59,13 @@ class Task(Base):
 
     # Set unique this way so that SQLite creates the constraint
     __table_args__ = (
-        UniqueConstraint("pipeline_id", "job_descriptor", name="unique_tasks"),
+        UniqueConstraint("version_id", "job_descriptor", name="unique_tasks"),
     )
 
     # Index('idx_unique_tasks', pipeline_id, job_descriptor, unique=True)
-    Index("idx_ordered_tasks", pipeline_id, created)
+    Index("idx_ordered_tasks", version_id, created)
 
-    pipeline = relationship("Pipeline", back_populates="tasks")
+    version = relationship("Version", back_populates="tasks")
     events = relationship("Event", back_populates="task")
 
     def convert_to_model(
@@ -74,7 +74,7 @@ class Task(Base):
         updated: datetime = None,
     ) -> ModelledTask | ModelledTaskExpanded:
         init_args = {
-            "pipeline": self.pipeline.convert_to_model(),
+            "pipeline": self.version.convert_to_api_pipeline(),
             "task_input_id": self.job_descriptor,
             "task_input": self.definition,
             "status": self.state,

--- a/src/npg_porch/db/models/task.py
+++ b/src/npg_porch/db/models/task.py
@@ -65,7 +65,7 @@ class Task(Base):
     # Index('idx_unique_tasks', pipeline_id, job_descriptor, unique=True)
     Index("idx_ordered_tasks", version_id, created)
 
-    version = relationship("Version", back_populates="tasks")
+    pipeline_version = relationship("Version", back_populates="tasks")
     events = relationship("Event", back_populates="task")
 
     def convert_to_model(
@@ -74,7 +74,7 @@ class Task(Base):
         updated: datetime = None,
     ) -> ModelledTask | ModelledTaskExpanded:
         init_args = {
-            "pipeline": self.version.convert_to_api_pipeline(),
+            "pipeline": self.pipeline_version.convert_to_api_pipeline(),
             "task_input_id": self.job_descriptor,
             "task_input": self.definition,
             "status": self.state,

--- a/src/npg_porch/db/models/version.py
+++ b/src/npg_porch/db/models/version.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 
-from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy import Column, Integer, String, ForeignKey, UniqueConstraint
 from sqlalchemy.orm import relationship
 
 from .base import Base
@@ -34,6 +34,7 @@ class Version(Base):
     version_id = Column(Integer, primary_key=True, autoincrement=True)
     version = Column(String, nullable=False)
     pipeline_id = Column(Integer, ForeignKey("pipeline.pipeline_id"), nullable=False)
+    unique_version = UniqueConstraint(version, pipeline_id, name="unique_version")
 
     pipeline = relationship("Pipeline", back_populates="versions")
     tasks = relationship("Task", back_populates="version")

--- a/src/npg_porch/db/models/version.py
+++ b/src/npg_porch/db/models/version.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2025 Genome Research Ltd.
+#
+# Author: Michael Kubiak mk35@sanger.ac.uk
+#
+# This file is part of npg_porch
+#
+# npg_porch is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation; either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy.orm import relationship
+
+from .base import Base
+
+from npg_porch.models import Pipeline as ModeledPipeline
+
+
+class Version(Base):
+    """
+    A pipeline version
+    """
+
+    __tablename__ = "version"
+    version_id = Column(Integer, primary_key=True, autoincrement=True)
+    version = Column(String, nullable=False)
+    pipeline_id = Column(Integer, ForeignKey("pipeline.pipeline_id"), nullable=False)
+
+    pipeline = relationship("Pipeline", back_populates="versions")
+    tasks = relationship("Task", back_populates="version")
+
+    def convert_to_api_pipeline(self):
+        """
+        Convert sqlalchemy object to npg_porch format.
+        """
+        return ModeledPipeline(
+            version=self.version,
+            name=self.pipeline.name,
+            uri=self.pipeline.repository_uri,
+        )

--- a/src/npg_porch/db/models/version.py
+++ b/src/npg_porch/db/models/version.py
@@ -37,7 +37,7 @@ class Version(Base):
     unique_version = UniqueConstraint(version, pipeline_id, name="unique_version")
 
     pipeline = relationship("Pipeline", back_populates="versions")
-    tasks = relationship("Task", back_populates="version")
+    tasks = relationship("Task", back_populates="pipeline_version")
 
     def convert_to_api_pipeline(self):
         """

--- a/src/npg_porch/endpoints/pipelines.py
+++ b/src/npg_porch/endpoints/pipelines.py
@@ -137,12 +137,12 @@ async def create_pipeline(
 
     try:
         new_pipeline = await db_accessor.create_pipeline(pipeline)
-    except IntegrityError as e:
+    except IntegrityError or TypeError as e:
         logging.info(str(e))
         if re.search("NOT NULL", str(e)):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Pipeline must specify a name and URI",
+                detail="Pipeline must specify a name, version and URI",
             )
         else:
             raise HTTPException(

--- a/src/npg_porch/endpoints/pipelines.py
+++ b/src/npg_porch/endpoints/pipelines.py
@@ -124,7 +124,7 @@ async def create_pipeline_token(
     },
     summary="Create one pipeline record.",
     description="""
-    Using JSON data in the request, creates a new pipeline record.
+    Using JSON data in the request, creates new pipeline and version records.
     A valid special power user token is required for authorisation.""",
 )
 async def create_pipeline(
@@ -137,16 +137,30 @@ async def create_pipeline(
         raise HTTPException(status_code=403)
 
     try:
-        new_pipeline = await db_accessor.create_pipeline(pipeline)
+        await db_accessor.create_pipeline(pipeline)
+    except IntegrityError as e:
+        logging.info(str(e))
+        if re.search("NOT NULL", str(e)):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Pipeline must specify a name and URI",
+            )
+        else:
+            logging.info("Pipeline already exists, skipping to version creation")
+            pass
+
+    try:
+        new_version = await db_accessor.create_version(pipeline)
     except IntegrityError as e:
         logging.error(str(e))
         if re.search("NOT NULL", str(e)):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Pipeline must specify a name and URI and version",
+                detail="Version must specify a version string",
             )
         else:
             raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT, detail="Pipeline already exists"
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Version already exists",
             )
-    return new_pipeline
+    return new_version

--- a/src/npg_porch/endpoints/pipelines.py
+++ b/src/npg_porch/endpoints/pipelines.py
@@ -48,15 +48,14 @@ router = APIRouter(
     summary="Get information about all pipelines.",
     description="""
     Returns a list of pydantic Pipeline models.
-    A uri and/or version filter can be used.
+    A uri filter can be used.
     A valid token issued for any pipeline is required for authorisation.""",
 )
 async def get_pipelines(
     uri: str | None = None,
-    version: str | None = None,
     db_accessor=Depends(get_DbAccessor),
 ) -> list[Pipeline]:
-    return await db_accessor.get_all_pipelines(uri, version)
+    return await db_accessor.get_all_pipelines(uri)
 
 
 @router.get(
@@ -122,7 +121,7 @@ async def create_pipeline_token(
         },
         status.HTTP_409_CONFLICT: {"description": "Pipeline already exists"},
     },
-    summary="Create one pipeline record.",
+    summary="Create one pipeline record and a linked version record.",
     description="""
     Using JSON data in the request, creates new pipeline and version records.
     A valid special power user token is required for authorisation.""",
@@ -137,7 +136,7 @@ async def create_pipeline(
         raise HTTPException(status_code=403)
 
     try:
-        await db_accessor.create_pipeline(pipeline)
+        new_pipeline = await db_accessor.create_pipeline(pipeline)
     except IntegrityError as e:
         logging.info(str(e))
         if re.search("NOT NULL", str(e)):
@@ -146,21 +145,10 @@ async def create_pipeline(
                 detail="Pipeline must specify a name and URI",
             )
         else:
-            logging.info("Pipeline already exists, skipping to version creation")
-            pass
-
-    try:
-        new_version = await db_accessor.create_version(pipeline)
-    except IntegrityError as e:
-        logging.error(str(e))
-        if re.search("NOT NULL", str(e)):
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Version must specify a version string",
-            )
-        else:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
-                detail="Version already exists",
+                detail="Pipeline already exists, use version api to create a "
+                "new version of an existing pipeline",
             )
-    return new_version
+
+    return new_pipeline

--- a/src/npg_porch/endpoints/tasks.py
+++ b/src/npg_porch/endpoints/tasks.py
@@ -28,6 +28,7 @@ from starlette import status
 
 from npg_porch.auth.token import validate
 from npg_porch.db.connection import get_DbAccessor
+from npg_porch.db.exceptions import IncompatibleArgumentsException
 from npg_porch.models import Pipeline
 from npg_porch.models.permission import PermissionValidationException
 from npg_porch.models.task import Task, TaskStateEnum
@@ -70,10 +71,16 @@ router = APIRouter(
 async def get_tasks(
     pipeline_name: str | None = None,
     status: TaskStateEnum | None = None,
+    pipeline_version: str | None = None,
     db_accessor=Depends(get_DbAccessor),
 ) -> list[Task]:
-    print(pipeline_name, status)
-    return await db_accessor.get_tasks(pipeline_name=pipeline_name, task_status=status)
+    try:
+        response = await db_accessor.get_tasks(
+            pipeline_name=pipeline_name, task_status=status, version=pipeline_version
+        )
+    except IncompatibleArgumentsException:
+        raise HTTPException(status_code=400)
+    return response
 
 
 @router.post(

--- a/src/npg_porch/endpoints/tasks.py
+++ b/src/npg_porch/endpoints/tasks.py
@@ -28,8 +28,8 @@ from starlette import status
 
 from npg_porch.auth.token import validate
 from npg_porch.db.connection import get_DbAccessor
+from npg_porch.models import Pipeline
 from npg_porch.models.permission import PermissionValidationException
-from npg_porch.models.pipeline import Pipeline
 from npg_porch.models.task import Task, TaskStateEnum
 
 
@@ -156,7 +156,7 @@ async def update_task(
             "description": "Receive a list of tasks that have been claimed"
         }
     },
-    summary="Claim tasks for a particular pipeline.",
+    summary="Claim tasks for a particular pipeline version.",
     description="""
     Arguments - the Pipeline object and the maximum number of tasks
     to retrieve and claim, the latter defaults to 1 if not given.
@@ -169,7 +169,7 @@ async def update_task(
 
     The pipeline object returned within each of the tasks is consistent
     with the pipeline object in the payload, but has all possible
-    attributes defined (uri, version).""",
+    attributes defined (pipeline, version).""",
 )
 async def claim_task(
     pipeline: Pipeline,

--- a/src/npg_porch/endpoints/versions.py
+++ b/src/npg_porch/endpoints/versions.py
@@ -39,7 +39,7 @@ router = APIRouter(
 
 
 @router.get(
-    "/{pipeline}",
+    "/{pipeline_name}",
     response_model=list[str],
     summary="Get information about version of a pipeline.",
     description="Returns a list of pydantic Version models for a specific pipeline.",

--- a/src/npg_porch/endpoints/versions.py
+++ b/src/npg_porch/endpoints/versions.py
@@ -88,7 +88,7 @@ async def create_version(
         )
     try:
         new_version = await db_accessor.create_version(pipeline)
-    except IntegrityError as e:
+    except IntegrityError or TypeError as e:
         logging.error(str(e))
         if "NOT NULL" in str(e):
             raise HTTPException(

--- a/src/npg_porch/endpoints/versions.py
+++ b/src/npg_porch/endpoints/versions.py
@@ -66,6 +66,7 @@ async def get_versions(
         status.HTTP_400_BAD_REQUEST: {
             "description": "Insufficient version properties provided"
         },
+        status.HTTP_404_NOT_FOUND: {"description": "Pipeline does not exist"},
         status.HTTP_409_CONFLICT: {
             "description": "Version already exists for this pipeline"
         },
@@ -104,6 +105,9 @@ async def create_version(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="Version already exists for this pipeline",
             )
-    # Except no pipeline?
+    except NoResultFound:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Pipeline does not exist"
+        )
 
     return new_version

--- a/src/npg_porch/endpoints/versions.py
+++ b/src/npg_porch/endpoints/versions.py
@@ -18,6 +18,7 @@
 # this program. If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.exc import IntegrityError
@@ -46,14 +47,8 @@ router = APIRouter(
 )
 async def get_versions(
     pipeline_name: str, db_accessor=Depends(get_DbAccessor)
-) -> list[Pipeline]:
-    versions = None
-    try:
-        versions = await db_accessor.get_pipeline_versions(pipeline_name=pipeline_name)
-    except NoResultFound:
-        raise HTTPException(
-            status_code=404, detail=f"Pipeline '{pipeline_name}' not _found"
-        )
+) -> list[str]:
+    versions = await db_accessor.get_pipeline_versions(pipeline_name=pipeline_name)
     return versions
 
 
@@ -105,9 +100,5 @@ async def create_version(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="Version already exists for this pipeline",
             )
-    except NoResultFound:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Pipeline does not exist"
-        )
 
     return new_version

--- a/src/npg_porch/endpoints/versions.py
+++ b/src/npg_porch/endpoints/versions.py
@@ -17,12 +17,17 @@
 # You should have received a copy of the GNU General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 from starlette import status
 
+from npg_porch.auth.token import validate
 from npg_porch.db.connection import get_DbAccessor
 from npg_porch.models.pipeline import Pipeline
+from npg_porch.models.permission import PermissionValidationException
 
 router = APIRouter(
     prefix="/versions",
@@ -50,3 +55,55 @@ async def get_versions(
             status_code=404, detail=f"Pipeline '{pipeline_name}' not _found"
         )
     return versions
+
+
+@router.post(
+    "/",
+    response_model=Pipeline,
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        status.HTTP_201_CREATED: {"description": "Version was created"},
+        status.HTTP_400_BAD_REQUEST: {
+            "description": "Insufficient version properties provided"
+        },
+        status.HTTP_409_CONFLICT: {
+            "description": "Version already exists for this pipeline"
+        },
+    },
+    summary="Create one version record.",
+    description="""
+    Using JSON data in the request, creates a new version record
+    for an existing pipeline.
+    A valid pipeline token is required for authorisation.
+    """,
+)
+async def create_version(
+    pipeline: Pipeline,
+    db_accessor=Depends(get_DbAccessor),
+    permission=Depends(validate),
+) -> Pipeline:
+    try:
+        permission.validate_pipeline(pipeline)
+    except PermissionValidationException as e:
+        logging.warning(str(e))
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Given credentials cannot be used for pipeline '{pipeline.name}'",
+        )
+    try:
+        new_version = await db_accessor.create_version(pipeline)
+    except IntegrityError as e:
+        logging.info(str(e))
+        if "NOT NULL" in str(e):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Version must specify a version and a complete pipeline",
+            )
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Version already exists for this pipeline",
+            )
+    # Except no pipeline?
+
+    return new_version

--- a/src/npg_porch/endpoints/versions.py
+++ b/src/npg_porch/endpoints/versions.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2025 Genome Research Ltd.
+#
+# Author: Michael Kubiak mk35@sanger.ac.uk
+#
+# This file is part of npg_porch
+#
+# npg_porch is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation; either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm.exc import NoResultFound
+from starlette import status
+
+from npg_porch.db.connection import get_DbAccessor
+from npg_porch.models.pipeline import Pipeline
+
+router = APIRouter(
+    prefix="/versions",
+    tags=["versions"],
+    responses={
+        status.HTTP_500_INTERNAL_SERVER_ERROR: {"description": "Unexpected error"},
+    },
+)
+
+
+@router.get(
+    "/{pipeline}",
+    response_model=list[str],
+    summary="Get information about version of a pipeline.",
+    description="Returns a list of pydantic Version models for a specific pipeline.",
+)
+async def get_versions(
+    pipeline_name: str, db_accessor=Depends(get_DbAccessor)
+) -> list[Pipeline]:
+    versions = None
+    try:
+        versions = await db_accessor.get_pipeline_versions(pipeline_name=pipeline_name)
+    except NoResultFound:
+        raise HTTPException(
+            status_code=404, detail=f"Pipeline '{pipeline_name}' not _found"
+        )
+    return versions

--- a/src/npg_porch/endpoints/versions.py
+++ b/src/npg_porch/endpoints/versions.py
@@ -81,7 +81,7 @@ async def create_version(
     try:
         permission.validate_pipeline(pipeline)
     except PermissionValidationException as e:
-        logging.warning(str(e))
+        logging.error(str(e))
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=f"Given credentials cannot be used for pipeline '{pipeline.name}'",
@@ -89,7 +89,7 @@ async def create_version(
     try:
         new_version = await db_accessor.create_version(pipeline)
     except IntegrityError as e:
-        logging.info(str(e))
+        logging.error(str(e))
         if "NOT NULL" in str(e):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,

--- a/src/npg_porch/endpoints/versions.py
+++ b/src/npg_porch/endpoints/versions.py
@@ -42,8 +42,8 @@ router = APIRouter(
 @router.get(
     "/{pipeline_name}",
     response_model=list[str],
-    summary="Get information about version of a pipeline.",
-    description="Returns a list of pydantic Version models for a specific pipeline.",
+    summary="Get information about versions of a pipeline.",
+    description="Returns a list of the available versions for a specific pipeline.",
 )
 async def get_versions(
     pipeline_name: str, db_accessor=Depends(get_DbAccessor)
@@ -93,7 +93,7 @@ async def create_version(
         if "NOT NULL" in str(e):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Version must specify a version and a complete pipeline",
+                detail="Message body must specify a version and a complete pipeline",
             )
         else:
             raise HTTPException(

--- a/src/npg_porch/models/task.py
+++ b/src/npg_porch/models/task.py
@@ -21,7 +21,12 @@ from datetime import datetime
 from enum import Enum
 import hashlib
 import ujson
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import (
+    BaseModel,
+    Field,
+    ValidationError,
+    field_serializer,
+)
 
 from npg_porch.models import Pipeline
 
@@ -114,5 +119,7 @@ class TaskExpanded(Task):
         description="The timestamp of task status update",
     )
 
-    class Config:
-        json_encoders = {datetime: lambda v: v.strftime("%Y-%m-%d\u00A0%H:%M:%S")}
+    @field_serializer("created", mode="plain")
+    @field_serializer("updated", mode="plain")
+    def serialise_datetime(self, value: datetime):
+        return value.strftime("%Y-%m-%d\u00A0%H:%M:%S")

--- a/src/npg_porch/models/task.py
+++ b/src/npg_porch/models/task.py
@@ -23,7 +23,7 @@ import hashlib
 import ujson
 from pydantic import BaseModel, Field, ValidationError
 
-from npg_porch.models.pipeline import Pipeline
+from npg_porch.models import Version
 
 
 class TaskStateEnum(str, Enum):
@@ -83,6 +83,7 @@ class Task(BaseModel):
             other_d = other.model_dump()
             if k == "pipeline":
                 truths.append(v["name"] == other_d[k]["name"])
+                truths.append(v["version"] == other_d[k]["version"])
             elif k == "task_input_id":
                 break
             elif k == "status":

--- a/src/npg_porch/models/task.py
+++ b/src/npg_porch/models/task.py
@@ -23,7 +23,7 @@ import hashlib
 import ujson
 from pydantic import BaseModel, Field, ValidationError
 
-from npg_porch.models import Version
+from npg_porch.models import Pipeline
 
 
 class TaskStateEnum(str, Enum):

--- a/src/npg_porch/server.py
+++ b/src/npg_porch/server.py
@@ -30,7 +30,7 @@ from fastapi.templating import Jinja2Templates
 from jinja2 import Environment, PackageLoader
 
 from npg_porch.db.connection import get_DbAccessor
-from npg_porch.endpoints import pipelines, tasks, ui
+from npg_porch.endpoints import pipelines, tasks, ui, versions
 from npg_porch.models import TaskStateEnum
 
 # https://fastapi.tiangolo.com/tutorial/bigger-applications/
@@ -61,6 +61,7 @@ app = FastAPI(
 app.include_router(pipelines.router)
 app.include_router(tasks.router)
 app.include_router(ui.router)
+app.include_router(versions.router)
 
 env = Environment(loader=PackageLoader("npg_porch", "templates"))
 templates = Jinja2Templates(env=env)

--- a/tests/data_access_test.py
+++ b/tests/data_access_test.py
@@ -23,8 +23,7 @@ async def store_me_a_pipeline(
     dac: AsyncDbAccessor, number: int = 1
 ) -> ModelledPipeline:
     pipeline_model = give_me_a_pipeline(number)
-    await dac.create_pipeline(pipeline_model.pipeline)
-    return await dac.create_version(pipeline_model)
+    return await dac.create_pipeline(pipeline_model.pipeline)
 
 
 def test_data_accessor_setup(async_session):
@@ -74,12 +73,10 @@ async def test_create_pipeline(db_accessor):
     pipeline = give_me_a_pipeline()
 
     saved_pipeline = await db_accessor.create_pipeline(pipeline)
-    saved_version = await db_accessor.create_version(pipeline)
 
     assert isinstance(saved_pipeline, ModelledPipeline)
-    assert isinstance(saved_version, ModelledPipeline)
     assert saved_pipeline.name == pipeline.name
-    assert saved_version.version == pipeline.version
+    assert saved_pipeline.version == pipeline.version
     assert saved_pipeline.uri == pipeline.uri
 
     with pytest.raises(AssertionError):
@@ -153,7 +150,7 @@ async def test_claim_tasks(db_accessor):
         assert exception.value == "Pipeline not found"
 
     # Now try again with a pipeline but no tasks
-    await db_accessor.create_version(pipeline)
+    await db_accessor.create_pipeline(pipeline)
     tasks = await db_accessor.claim_tasks(1, pipeline)
     assert isinstance(tasks, list)
     assert len(tasks) == 0
@@ -301,7 +298,7 @@ async def test_get_tasks(db_accessor):
 
     tasks = await db_accessor.get_tasks(pipeline_name="ptest one")
     assert len(tasks) == 2, "New tasks filtered out by pipeline name"
-    assert tasks[0].version.pipeline.name == "ptest one"
+    assert tasks[0].pipeline.name == "ptest one"
 
     # Change one task to another status
     await db_accessor.update_task(

--- a/tests/data_access_test.py
+++ b/tests/data_access_test.py
@@ -13,8 +13,8 @@ from sqlalchemy.orm.exc import NoResultFound
 
 def give_me_a_pipeline(number: int = 1):
     return ModelledPipeline(
-        name=f"ptest {number}",
         version=str(number),
+        name=f"ptest {number}",
         uri=f"file:///team117/test_pipeline{number}",
     )
 
@@ -22,7 +22,9 @@ def give_me_a_pipeline(number: int = 1):
 async def store_me_a_pipeline(
     dac: AsyncDbAccessor, number: int = 1
 ) -> ModelledPipeline:
-    return await dac.create_pipeline(give_me_a_pipeline(number))
+    pipeline_model = give_me_a_pipeline(number)
+    await dac.create_pipeline(pipeline_model.pipeline)
+    return await dac.create_version(pipeline_model)
 
 
 def test_data_accessor_setup(async_session):
@@ -44,7 +46,6 @@ async def test_get_pipeline(db_accessor):
     pipeline = await db_accessor.get_pipeline_by_name("ptest one")
     assert pipeline
     assert pipeline.name == "ptest one"
-    assert pipeline.version == "0.3.14"
 
 
 @pytest.mark.asyncio
@@ -57,23 +58,11 @@ async def test_get_all_pipelines(db_accessor):
 
     # Make a second pipeline with the same version and different uri as the one in the fixture
     await db_accessor.create_pipeline(
-        ModelledPipeline(
-            name="ptest two", version="0.3.14", uri="test-the-other-one.com"
-        )
+        ModelledPipeline(name="ptest two", uri="test-the-other-one.com")
     )
-
-    pipes = await db_accessor.get_all_pipelines(version="0.3.14")
-    assert len(pipes) == 2
 
     pipes = await db_accessor.get_all_pipelines(uri="test-the-other-one.com")
     assert len(pipes) == 1
-
-    pipes = await db_accessor.get_all_pipelines(
-        version="0.3.14", uri="pipeline-test.com"
-    )
-    assert (
-        len(pipes) == 1
-    ), "Both parameters work together, even if it does not reduce the results"
 
 
 @pytest.mark.asyncio
@@ -81,10 +70,12 @@ async def test_create_pipeline(db_accessor):
     pipeline = give_me_a_pipeline()
 
     saved_pipeline = await db_accessor.create_pipeline(pipeline)
+    saved_version = await db_accessor.create_version(pipeline)
 
     assert isinstance(saved_pipeline, ModelledPipeline)
+    assert isinstance(saved_version, ModelledPipeline)
     assert saved_pipeline.name == pipeline.name
-    assert saved_pipeline.version == pipeline.version
+    assert saved_version.version == pipeline.version
     assert saved_pipeline.uri == pipeline.uri
 
     with pytest.raises(AssertionError):
@@ -94,6 +85,10 @@ async def test_create_pipeline(db_accessor):
         await db_accessor.create_pipeline(pipeline)
 
         assert re.match("UNIQUE constraint failed", exception.value)
+    with pytest.raises(IntegrityError) as exception:
+        await db_accessor.create_version(pipeline)
+
+        assert "UNIQUE constraint failed" in exception.value
 
 
 @pytest.mark.asyncio
@@ -141,7 +136,7 @@ async def test_claim_tasks(db_accessor):
         assert exception.value == "Pipeline not found"
 
     # Now try again with a pipeline but no tasks
-    await db_accessor.create_pipeline(pipeline)
+    await db_accessor.create_version(pipeline)
     tasks = await db_accessor.claim_tasks(1, pipeline)
     assert isinstance(tasks, list)
     assert len(tasks) == 0

--- a/tests/data_access_test.py
+++ b/tests/data_access_test.py
@@ -79,7 +79,7 @@ async def test_create_pipeline(db_accessor):
     assert saved_pipeline.version == pipeline.version
     assert saved_pipeline.uri == pipeline.uri
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
         await db_accessor.create_pipeline({})
     with pytest.raises(IntegrityError) as exception:
         # Making duplicate provides a useful error
@@ -97,7 +97,7 @@ async def test_create_version(db_accessor):
     saved_new_version = await db_accessor.create_version(new_version)
     assert saved_new_version.version == "2.0"
     assert saved_new_version.name == saved_version.name
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
         await db_accessor.create_version({})
     with pytest.raises(IntegrityError) as exception:
         await db_accessor.create_version(pipeline)

--- a/tests/data_access_test.py
+++ b/tests/data_access_test.py
@@ -58,7 +58,11 @@ async def test_get_all_pipelines(db_accessor):
 
     # Make a second pipeline with the same version and different uri as the one in the fixture
     await db_accessor.create_pipeline(
-        ModelledPipeline(name="ptest two", uri="test-the-other-one.com")
+        ModelledPipeline(
+            name="ptest two",
+            uri="test-the-other-one.com",
+            version="0.3.14",
+        )
     )
 
     pipes = await db_accessor.get_all_pipelines(uri="test-the-other-one.com")
@@ -85,6 +89,19 @@ async def test_create_pipeline(db_accessor):
         await db_accessor.create_pipeline(pipeline)
 
         assert re.match("UNIQUE constraint failed", exception.value)
+
+
+@pytest.mark.asyncio
+async def test_create_version(db_accessor):
+    pipeline = give_me_a_pipeline()
+    saved_version = await db_accessor.create_pipeline(pipeline)
+
+    new_version = ModelledPipeline(version="2.0", name=pipeline.name, uri=pipeline.uri)
+    saved_new_version = await db_accessor.create_version(new_version)
+    assert saved_new_version.version == "2.0"
+    assert saved_new_version.name == saved_version.name
+    with pytest.raises(AssertionError):
+        await db_accessor.create_version({})
     with pytest.raises(IntegrityError) as exception:
         await db_accessor.create_version(pipeline)
 
@@ -284,7 +301,7 @@ async def test_get_tasks(db_accessor):
 
     tasks = await db_accessor.get_tasks(pipeline_name="ptest one")
     assert len(tasks) == 2, "New tasks filtered out by pipeline name"
-    assert tasks[0].pipeline.name == "ptest one"
+    assert tasks[0].version.pipeline.name == "ptest one"
 
     # Change one task to another status
     await db_accessor.update_task(

--- a/tests/data_access_test.py
+++ b/tests/data_access_test.py
@@ -23,7 +23,7 @@ async def store_me_a_pipeline(
     dac: AsyncDbAccessor, number: int = 1
 ) -> ModelledPipeline:
     pipeline_model = give_me_a_pipeline(number)
-    return await dac.create_pipeline(pipeline_model.pipeline)
+    return await dac.create_pipeline(pipeline_model)
 
 
 def test_data_accessor_setup(async_session):
@@ -299,6 +299,24 @@ async def test_get_tasks(db_accessor):
     tasks = await db_accessor.get_tasks(pipeline_name="ptest one")
     assert len(tasks) == 2, "New tasks filtered out by pipeline name"
     assert tasks[0].pipeline.name == "ptest one"
+
+    # Test tasks in a different version of the same pipeline
+
+    new_version = ModelledPipeline(version="1.8", name=pipeline.name, uri=pipeline.uri)
+    saved_new_version = await db_accessor.create_version(new_version)
+
+    for i in range(3):
+        await db_accessor.create_task(
+            token_id=1,
+            task=Task(
+                task_input={"number": i + 1},
+                pipeline=saved_new_version,
+                status=TaskStateEnum.PENDING,
+            ),
+        )
+
+    pipeline_tasks = await db_accessor.get_tasks(pipeline_name=pipeline.name)
+    assert len(pipeline_tasks) == 6, "6 tasks in this pipeline, 3 in each version"
 
     # Change one task to another status
     await db_accessor.update_task(

--- a/tests/db_auth_test.py
+++ b/tests/db_auth_test.py
@@ -68,11 +68,7 @@ async def test_permission_object_is_returned(async_minimum):
     # The fixtures have a token not associated with any pipeline.
     # To model data realistically, create a pipeline not associated
     # with any token.
-    async_minimum.add(
-        Pipeline(
-            name="ptest ten", repository_uri="pipeline-testten.com", version="0.3.15"
-        )
-    )
+    async_minimum.add(Pipeline(name="ptest ten", repository_uri="pipeline-testten.com"))
     await async_minimum.commit()
 
     v = Validator(session=async_minimum)

--- a/tests/db_task_test.py
+++ b/tests/db_task_test.py
@@ -19,7 +19,7 @@ async def test_task_creation(async_minimum):
         task_a.job_descriptor
         == "8cb72a9439dc643d67e859ceca424b9327a9c1abf9c772525df299f656137c22"
     )  # noqa: E501
-    assert task_a.pipeline.repository_uri == "pipeline-test.com"
+    assert task_a.version.pipeline.repository_uri == "pipeline-test.com"
     events = task_a.events
     assert len(events) == 1
     assert events[0].change == "Created"

--- a/tests/db_task_test.py
+++ b/tests/db_task_test.py
@@ -19,7 +19,7 @@ async def test_task_creation(async_minimum):
         task_a.job_descriptor
         == "8cb72a9439dc643d67e859ceca424b9327a9c1abf9c772525df299f656137c22"
     )  # noqa: E501
-    assert task_a.version.pipeline.repository_uri == "pipeline-test.com"
+    assert task_a.pipeline_version.pipeline.repository_uri == "pipeline-test.com"
     events = task_a.events
     assert len(events) == 1
     assert events[0].change == "Created"

--- a/tests/fixtures/deploy_db.py
+++ b/tests/fixtures/deploy_db.py
@@ -38,14 +38,14 @@ def minimum_data():
     b_event = Event(token=tokens[0], change="Created")
     tasks = [
         Task(
-            version=version,
+            pipeline_version=version,
             events=[a_event],
             job_descriptor="8cb72a9439dc643d67e859ceca424b9327a9c1abf9c772525df299f656137c22",
             definition={"to_do": "stuff", "why": "reasons"},
             state=TaskStateEnum.PENDING,
         ),
         Task(
-            version=version,
+            pipeline_version=version,
             events=[b_event],
             # Probably wrong job_descriptor
             job_descriptor="4994ef1668bc9614bf0a8f199da50345e85e8b714ab91e95cf619c74af7d3eda",
@@ -85,7 +85,7 @@ def lots_of_tasks():
             status=TaskStateEnum.PENDING,
         )
         t_db = Task(
-            version=version,
+            pipeline_version=version,
             job_descriptor=t.generate_task_id(),
             state=t.status,
             definition=t.task_input,
@@ -120,7 +120,7 @@ def past_tasks():
 
     tasks = [
         Task(
-            version=version,
+            pipeline_version=version,
             definition={"Shared": "input"},
             events=[day_one_events[i]],
             state=TaskStateEnum.PENDING,

--- a/tests/fixtures/deploy_db.py
+++ b/tests/fixtures/deploy_db.py
@@ -5,7 +5,7 @@ import pytest
 import pytest_asyncio
 from starlette.testclient import TestClient
 
-from npg_porch.db.models import Pipeline, Task, Event, Token
+from npg_porch.db.models import Pipeline, Task, Event, Token, Version
 from npg_porch.db.data_access import AsyncDbAccessor
 from npg_porch.models import Task as ModelledTask, TaskStateEnum
 from npg_porch.server import app
@@ -19,9 +19,9 @@ NOW = datetime.now()
 def minimum_data():
     "Provides one or two of everything"
 
-    pipeline = Pipeline(
-        name="ptest one", repository_uri="pipeline-test.com", version="0.3.14"
-    )
+    pipeline = Pipeline(name="ptest one", repository_uri="pipeline-test.com")
+    version = Version(pipeline=pipeline, version="0.3.14")
+
     tokens = [
         Token(
             token="cac0533d5599489d9a3d998028a79fe8",
@@ -38,14 +38,14 @@ def minimum_data():
     b_event = Event(token=tokens[0], change="Created")
     tasks = [
         Task(
-            pipeline=pipeline,
+            version=version,
             events=[a_event],
             job_descriptor="8cb72a9439dc643d67e859ceca424b9327a9c1abf9c772525df299f656137c22",
             definition={"to_do": "stuff", "why": "reasons"},
             state=TaskStateEnum.PENDING,
         ),
         Task(
-            pipeline=pipeline,
+            version=version,
             events=[b_event],
             # Probably wrong job_descriptor
             job_descriptor="4994ef1668bc9614bf0a8f199da50345e85e8b714ab91e95cf619c74af7d3eda",
@@ -54,7 +54,7 @@ def minimum_data():
         ),
     ]
 
-    entities = UserList([pipeline, b_event, a_event])
+    entities = UserList([pipeline, version, b_event, a_event])
     entities.extend(tokens)
     entities.extend(tasks)
 
@@ -65,9 +65,9 @@ def minimum_data():
 def lots_of_tasks():
     "A good supply of tasks for testing claims"
 
-    pipeline = Pipeline(
-        name="ptest some", repository_uri="pipeline-test.com", version="0.3.14"
-    )
+    pipeline = Pipeline(name="ptest some", repository_uri="pipeline-test.com")
+    a_version = Version(pipeline=pipeline, version="0.3.14")
+    b_version = Version(pipeline=pipeline, version="0.3.15")
     job_finder_token = Token(
         token="ba53eaf7073d4c2b95ca47aeed41086c",
         pipeline=pipeline,
@@ -76,22 +76,23 @@ def lots_of_tasks():
 
     tasks = []
     for i in range(0, 10):
+        version, v_string = (a_version, "0.3.14") if i < 5 else (b_version, "0.3.15")
         # A convoluted way of running generate_task_id() so we can set it
         # correctly in the DB without going through the API
         t = ModelledTask(
-            pipeline={"name": "does not matter"},
+            pipeline={"version": v_string, "name": "does not matter"},
             task_input={"input": i + 1},
             status=TaskStateEnum.PENDING,
         )
         t_db = Task(
-            pipeline=pipeline,
+            version=version,
             job_descriptor=t.generate_task_id(),
             state=t.status,
             definition=t.task_input,
         )
         tasks.append(t_db)
 
-    entities = UserList([pipeline, job_finder_token])
+    entities = UserList([pipeline, a_version, b_version, job_finder_token])
     for t in tasks:
         entities.append(t)
     return entities
@@ -99,9 +100,8 @@ def lots_of_tasks():
 
 @pytest.fixture
 def past_tasks():
-    pipeline = Pipeline(
-        name="ptest_one", repository_uri="pipeline-test.com", version="0.3.14"
-    )
+    pipeline = Pipeline(name="ptest_one", repository_uri="pipeline-test.com")
+    version = Version(pipeline=pipeline, version="0.3.14")
     token = Token(
         token="cac0533d5599489d9a3d998028a79fe0",
         pipeline=pipeline,
@@ -139,7 +139,7 @@ def past_tasks():
         index += 1
         tasks[index].state = TaskStateEnum.DONE
 
-    entities = UserList([pipeline, token])
+    entities = UserList([pipeline, version, token])
     entities.extend(day_one_events)
     entities.extend(early_events)
     entities.extend(recent_events)

--- a/tests/fixtures/deploy_db.py
+++ b/tests/fixtures/deploy_db.py
@@ -120,7 +120,7 @@ def past_tasks():
 
     tasks = [
         Task(
-            pipeline=pipeline,
+            version=version,
             definition={"Shared": "input"},
             events=[day_one_events[i]],
             state=TaskStateEnum.PENDING,

--- a/tests/pipeline_route_test.py
+++ b/tests/pipeline_route_test.py
@@ -19,7 +19,7 @@ def http_create_pipeline(fastapi_testclient, pipeline):
     response = fastapi_testclient.post(
         "/pipelines", json=pipeline.model_dump(), follow_redirects=True
     )
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     response = fastapi_testclient.post(
         "/pipelines", json=pipeline.model_dump(), follow_redirects=True, headers=headers
@@ -96,7 +96,7 @@ def test_create_pipeline(async_minimum, fastapi_testclient):
         follow_redirects=True,
         headers=headers4power_user,
     )
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
     # Create a pipeline
     desired_pipeline = Pipeline(

--- a/tests/pipeline_route_test.py
+++ b/tests/pipeline_route_test.py
@@ -43,7 +43,6 @@ def test_pipeline_get(async_minimum, fastapi_testclient):
     pipeline = Pipeline.model_validate(response.json()[0])
     assert pipeline, "Response fits into the over-the-wire model"
     assert pipeline.name == "ptest one"
-    assert pipeline.version == "0.3.14"
 
 
 def test_pipeline_filtered_get(async_minimum, fastapi_testclient):
@@ -58,16 +57,18 @@ def test_pipeline_filtered_get(async_minimum, fastapi_testclient):
     http_create_pipeline(fastapi_testclient, second_pipeline)
     http_create_pipeline(fastapi_testclient, third_pipeline)
 
-    response = fastapi_testclient.get("/pipelines?version=0.3.14", headers=headers)
-    assert response.status_code == status.HTTP_200_OK
-    pipes = response.json()
-    assert len(pipes) == 3, "All three pipelines have the same version"
+    # Would it be useful to put this functionality back in?
+    # response = fastapi_testclient.get("/pipelines?version=0.3.14", headers=headers)
+    # assert response.status_code == status.HTTP_200_OK
+    # pipes = response.json()
+    # assert len(pipes) == 3, "All three pipelines have the same version"
 
     response = fastapi_testclient.get("/pipelines?uri=http://test.com", headers=headers)
     assert response.status_code == status.HTTP_200_OK
     pipes = response.json()
     assert len(pipes) == 1, "Only one pipeline matches the uri"
-    assert pipes[0] == second_pipeline.model_dump()
+    assert pipes[0]["name"] == second_pipeline.name
+    assert pipes[0]["uri"] == second_pipeline.uri
 
 
 def test_get_known_pipeline(async_minimum, fastapi_testclient):
@@ -77,7 +78,6 @@ def test_get_known_pipeline(async_minimum, fastapi_testclient):
     pipeline = Pipeline.model_validate(response.json())
     assert pipeline, "Response fits into the over-the-wire model"
     assert pipeline.name == "ptest one"
-    assert pipeline.version == "0.3.14"
 
     response = fastapi_testclient.get("/pipelines/not here", headers=headers)
     assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -99,7 +99,9 @@ def test_create_pipeline(async_minimum, fastapi_testclient):
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
     # Create a pipeline
-    desired_pipeline = Pipeline(name="ptest two", uri="http://test.com", version="1")
+    desired_pipeline = Pipeline(
+        name="ptest two", uri="http://test.com", version="0.3.14"
+    )
 
     response = http_create_pipeline(fastapi_testclient, desired_pipeline)
     pipeline = Pipeline.model_validate(response)
@@ -113,7 +115,11 @@ def test_create_pipeline(async_minimum, fastapi_testclient):
         headers=headers4power_user,
     )
     assert response.status_code == status.HTTP_409_CONFLICT, "ptest two already in DB"
-    assert response.json()["detail"] == "Pipeline already exists"
+    assert (
+        response.json()["detail"]
+        == "Pipeline already exists, use version api to create a new version of "
+        "an existing pipeline"
+    )
 
     # Create a different pipeline
     second_desired_pipeline = Pipeline(
@@ -125,10 +131,10 @@ def test_create_pipeline(async_minimum, fastapi_testclient):
     # Retrieve the same pipelines
     response = fastapi_testclient.get("/pipelines", headers=headers)
     assert response.status_code == status.HTTP_200_OK
-    assert response.json()[1:] == [
-        desired_pipeline.model_dump(),
-        second_desired_pipeline.model_dump(),
-    ]
+    assert response.json()[1]["name"] == desired_pipeline.name
+    assert response.json()[1]["uri"] == desired_pipeline.uri
+    assert response.json()[2]["name"] == second_desired_pipeline.name
+    assert response.json()[2]["uri"] == second_desired_pipeline.uri
 
     # Create a very poorly provenanced pipeline
     third_desired_pipeline = Pipeline(

--- a/tests/task_model_test.py
+++ b/tests/task_model_test.py
@@ -6,7 +6,7 @@ from npg_porch.models import Pipeline
 
 def test_expanded_task_date_format():
     pipeline = Pipeline(
-        name="pipeline", version="1.0", uri="file:///team117/test_pipeline"
+        name="pipeline", uri="file:///team117/test_pipeline", version="1.0"
     )
     task = TaskExpanded(
         pipeline=pipeline,

--- a/tests/task_route_test.py
+++ b/tests/task_route_test.py
@@ -1,4 +1,4 @@
-from npg_porch.models import Pipeline, Task, TaskStateEnum
+from npg_porch.models import Task, TaskStateEnum, Pipeline
 from starlette import status
 
 # Not testing get-all-tasks as this method will ultimately go
@@ -16,7 +16,7 @@ headers4ptest_some = {
 def test_task_creation(async_minimum, fastapi_testclient):
     # Create a task with a sparse pipeline definition
     task_one = Task(
-        pipeline={"name": "ptest one"},
+        pipeline={"name": "ptest one", "version": "0.3.14"},
         task_input={"number": 1},
         status=TaskStateEnum.PENDING,
     )
@@ -43,7 +43,7 @@ def test_task_creation(async_minimum, fastapi_testclient):
     assert response.json() == response_obj
 
     task_two = Task(
-        pipeline={"name": "ptest none"},
+        pipeline={"name": "ptest none", "version": "0.3.14"},
         task_input={"number": 1},
         status=TaskStateEnum.PENDING,
     )
@@ -85,7 +85,9 @@ def test_task_update(async_minimum, fastapi_testclient):
     # And change the reference pipeline to something wrong.
     # This token is valid, but for a different pipeline. It is impossible
     # to have a valid token for a pipeline that does not exist.
-    modified_task.pipeline = Pipeline.model_validate({"name": "ptest one thousand"})
+    modified_task.pipeline = Pipeline.model_validate(
+        {"name": "ptest one thousand", "version": "1.0"}
+    )
     response = fastapi_testclient.put(
         "/tasks",
         json=modified_task.model_dump(),
@@ -96,22 +98,21 @@ def test_task_update(async_minimum, fastapi_testclient):
 
 
 def test_task_claim(async_minimum, async_tasks, fastapi_testclient):
-    response = fastapi_testclient.get(
-        "/pipelines/ptest some", headers=headers4ptest_one
-    )
+    response = fastapi_testclient.get("/versions/ptest some", headers=headers4ptest_one)
     assert response.status_code == status.HTTP_200_OK
 
-    pipeline = response.json()
+    version_1 = Pipeline(version=response.json()[0], name="ptest some")
+    version_2 = Pipeline(version=response.json()[1], name="ptest some")
     tasks_seen = []
 
     # Cannot claim with a token issued for a different pipeline.
     response = fastapi_testclient.post(
-        "/tasks/claim", json=pipeline, headers=headers4ptest_one
+        "/tasks/claim", json=version_1.model_dump(), headers=headers4ptest_one
     )
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
     response = fastapi_testclient.post(
-        "/tasks/claim", json=pipeline, headers=headers4ptest_some
+        "/tasks/claim", json=version_1.model_dump(), headers=headers4ptest_some
     )
     assert response.status_code == status.HTTP_200_OK
     tasks = response.json()
@@ -122,14 +123,18 @@ def test_task_claim(async_minimum, async_tasks, fastapi_testclient):
     tasks_seen.append(t["task_input_id"])
 
     response = fastapi_testclient.post(
-        "/tasks/claim?num_tasks=0", json=pipeline, headers=headers4ptest_some
+        "/tasks/claim?num_tasks=0",
+        json=version_1.model_dump(),
+        headers=headers4ptest_some,
     )
     assert (
         response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     ), "Not allowed to use invalid numbers of tasks"  # noqa: E501
 
     response = fastapi_testclient.post(
-        "/tasks/claim?num_tasks=2", json=pipeline, headers=headers4ptest_some
+        "/tasks/claim?num_tasks=2",
+        json=version_1.model_dump(),
+        headers=headers4ptest_some,
     )
     assert response.status_code == status.HTTP_200_OK
     tasks = response.json()
@@ -139,16 +144,29 @@ def test_task_claim(async_minimum, async_tasks, fastapi_testclient):
     # Cannot test race conditions, because sqlite only pretends to support full async
     # Claim the rest
     response = fastapi_testclient.post(
-        "/tasks/claim?num_tasks=8", json=pipeline, headers=headers4ptest_some
+        "/tasks/claim?num_tasks=8",
+        json=version_1.model_dump(),
+        headers=headers4ptest_some,
     )
     assert response.status_code == status.HTTP_200_OK
     tasks = response.json()
-    assert len(tasks) == 7, "Asked for eight, got seven"
+    assert len(tasks) == 2, "Asked for eight, got two"
+    tasks_seen.extend([t["task_input_id"] for t in tasks])
+
+    # Claim tasks from the other pipeline version
+    response = fastapi_testclient.post(
+        "/tasks/claim?num_tasks=10",
+        json=version_2.model_dump(),
+        headers=headers4ptest_some,
+    )
+    assert response.status_code == status.HTTP_200_OK
+    tasks = response.json()
+    assert len(tasks) == 5, "Asked for ten, got five"
     tasks_seen.extend([t["task_input_id"] for t in tasks])
     assert len(set(tasks_seen)) == 10, "Ten unique tasks were claimed"
 
     response = fastapi_testclient.post(
-        "/tasks/claim", json=pipeline, headers=headers4ptest_some
+        "/tasks/claim", json=version_2.model_dump(), headers=headers4ptest_some
     )
     assert response.status_code == status.HTTP_200_OK
     tasks = response.json()

--- a/tests/task_route_test.py
+++ b/tests/task_route_test.py
@@ -128,7 +128,7 @@ def test_task_claim(async_minimum, async_tasks, fastapi_testclient):
         headers=headers4ptest_some,
     )
     assert (
-        response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
     ), "Not allowed to use invalid numbers of tasks"  # noqa: E501
 
     response = fastapi_testclient.post(

--- a/tests/task_route_test.py
+++ b/tests/task_route_test.py
@@ -225,3 +225,8 @@ def test_get_tasks(async_minimum, async_tasks, fastapi_testclient):
     print(response.text)
     tasks = response.json()
     assert len(tasks) == 0, "but no tasks are returned that match status and pipeline"
+
+    response = fastapi_testclient.get(
+        '/tasks?pipeline_version="0.3.14"', headers=headers4ptest_one
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/tests/ui_route_test.py
+++ b/tests/ui_route_test.py
@@ -36,7 +36,7 @@ async def test_get_ui_tasks(db_accessor, async_past_tasks):
     ), "Two tasks have failed within the last 14 days"
 
     modelled_pipeline = Pipeline(
-        name="new_pipeline", version="1.0", uri="file://test.pipeline"
+        name="new_pipeline", uri="file://test.pipeline", version="1.0"
     )
     pipeline = await db_accessor.create_pipeline(modelled_pipeline)
 
@@ -70,7 +70,7 @@ async def test_get_ui_tasks(db_accessor, async_past_tasks):
 @pytest.mark.asyncio
 async def test_get_long_running_ui_tasks(db_accessor):
     modelled_pipeline = Pipeline(
-        name="test_pipeline", version="1.0", uri="file://test.pipeline"
+        name="test_pipeline", uri="file://test.pipeline", version="1.0"
     )
     pipeline = await db_accessor.create_pipeline(modelled_pipeline)
 

--- a/tests/version_route_test.py
+++ b/tests/version_route_test.py
@@ -20,7 +20,7 @@ def test_create_version(async_minimum, fastapi_testclient):
         "/versions", json=pipeline.model_dump(), follow_redirects=True
     )
     assert (
-        response.status_code == status.HTTP_403_FORBIDDEN
+        response.status_code == status.HTTP_401_UNAUTHORIZED
     ), "Fails to create version with no authentication"
 
     response = fastapi_testclient.post(

--- a/tests/version_route_test.py
+++ b/tests/version_route_test.py
@@ -1,0 +1,106 @@
+import pytest
+from starlette import status
+
+from npg_porch.models import Pipeline
+
+headers = {
+    "Authorization": "Bearer cac0533d5599489d9a3d998028a79fe8",
+    "accept": "application/json",
+}
+headers4power_user = {
+    "Authorization": "Bearer 4bab73544c834c6f86f9662e5de26d0d",
+    "accept": "application/json",
+}
+
+
+def test_create_version(async_minimum, fastapi_testclient):
+    pipeline = Pipeline(name="new_pipeline", uri="test.pipeline", version="1.0")
+    version_two = Pipeline(version="2.0", name="new_pipeline", uri="test.pipeline")
+    response = fastapi_testclient.post(
+        "/versions", json=pipeline.model_dump(), follow_redirects=True
+    )
+    assert (
+        response.status_code == status.HTTP_403_FORBIDDEN
+    ), "Fails to create version with no authentication"
+
+    response = fastapi_testclient.post(
+        "/versions",
+        json=pipeline.model_dump(),
+        follow_redirects=True,
+        headers=headers4power_user,
+    )
+    assert (
+        response.status_code == status.HTTP_403_FORBIDDEN
+    ), "Fails to create version with admin authentication"
+
+    p_response = fastapi_testclient.post(
+        "/pipelines",
+        json=pipeline.model_dump(),
+        follow_redirects=True,
+        headers=headers4power_user,
+    )
+
+    response = fastapi_testclient.post(
+        "/versions",
+        json=version_two.model_dump(),
+        follow_redirects=True,
+        headers=headers,
+    )
+    assert (
+        response.status_code == status.HTTP_403_FORBIDDEN
+    ), "Authentication for wrong pipeline"
+
+    response = fastapi_testclient.post(
+        "/pipelines/new_pipeline/token/new_token",
+        follow_redirects=True,
+        headers=headers4power_user,
+    )
+    token_headers = {
+        "Authorization": f"Bearer {response.json()['token']}",
+        "accept": "application/json",
+    }
+
+    response = fastapi_testclient.post(
+        "/versions",
+        json=pipeline.model_dump(),
+        follow_redirects=True,
+        headers=token_headers,
+    )
+    assert response.status_code == status.HTTP_409_CONFLICT, "Version already exists"
+
+    response = fastapi_testclient.post(
+        "/versions",
+        json=version_two.model_dump(),
+        follow_redirects=True,
+        headers=token_headers,
+    )
+    assert (
+        response.status_code == status.HTTP_201_CREATED
+    ), "Version created successfully"
+
+
+def test_get_versions(async_minimum, fastapi_testclient):
+    versions = [
+        {
+            "name": "ptest one",
+            "uri": "pipeline-test.com",
+            "version": "0.3.14",
+        },
+        {
+            "name": "ptest one",
+            "uri": "pipeline-test.com",
+            "version": "1.0.0",
+        },
+    ]
+
+    response = fastapi_testclient.get("/versions/fake pipeline")
+    assert response.json() == []
+    response = fastapi_testclient.get("/versions/ptest one")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == [versions[0]["version"]]
+    fastapi_testclient.post(
+        "/versions", json=versions[1], follow_redirects=True, headers=headers
+    )
+    response = fastapi_testclient.get("/versions/ptest one")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == ["0.3.14", "1.0.0"]


### PR DESCRIPTION
This pr covers https://jira.sanger.ac.uk/browse/NPG-3566, https://jira.sanger.ac.uk/browse/NPG-3567 and https://jira.sanger.ac.uk/browse/NPG-3568 because there was no point at which one individual set of changes worked in a demonstrable way.

The remaining steps to release this will be:

1. Update dev database (after running the below tests with the current version) - Update schema to add version table and relationships (see changes to db models for specific columns and keys). Write and run script to copy current versions from pipeline table to version table and relate tasks and pipelines to the proper versions. Remove version from pipeline table, and pipeline foreign key from task table.
2. Test with a larger dataset - This will involve timing queries against the database and comparing to equivalent queries against the previous version on the same data set - creating and getting pipelines/tasks/versions, claiming and updating tasks - and checking that the web ui loads fast enough.
3. Update prod database using the same process as dev as well as replacing the clients (Avnish can help).

An improvement on https://github.com/wtsi-npg/npg_porch/pull/107 which had unwanted changes to the api.