### PR TITLE
Add web UI to allow task state to be edited

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -262,3 +262,28 @@ A failed task might be rerun by changing this status from FAILED to PENDING, suc
 Inevitably a pipeline will fail: Disk full, segfault, missing data, missing dependency etc.
 
 T.B.C.
+
+### Web UI - change multiple task states
+
+The web UI (`/`) also supports editing task status directly in the table, including filtered views (`/long_running` and `/recently_failed`).
+
+1. Select new status values in one or more task rows.
+2. Click `Apply State Changes`.
+3. Enter a bearer token in the dialog when prompted.
+4. The UI sends one `PUT /tasks` request per changed row using the same task payload shape used by API clients:
+
+```javascript
+{
+    "pipeline": {
+        "name": "My First Pipeline",
+        "version": "1.0"
+    },
+    "task_input": {
+        "study_id": 100,
+        "id_run": 45925
+    },
+    "status": "RUNNING"
+}
+```
+
+The page reports a summary (`N updated, M failed`) and keeps failed rows marked so that you can correct and retry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,6 @@ db = [
     ]
 
 [tool.setuptools_scm]
+
+[tool.setuptools.package-data]
+npg_porch = ["templates/*.j2", "static/*.css", "static/*.js"]

--- a/src/npg_porch/auth/ui_session.py
+++ b/src/npg_porch/auth/ui_session.py
@@ -1,0 +1,147 @@
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+import os
+from secrets import compare_digest, token_urlsafe
+from threading import Lock
+
+from fastapi import HTTPException, Request
+from starlette import status
+from starlette.responses import Response
+
+from npg_porch.models.permission import Permission
+
+UI_SESSION_COOKIE_NAME = "npg_porch_ui_session"
+UI_CSRF_HEADER_NAME = "X-CSRF-Token"
+UI_SESSION_TTL_SECONDS = int(os.environ.get("NPG_PORCH_UI_SESSION_TTL", "1800"))
+UI_SESSION_COOKIE_SECURE = os.environ.get("NPG_PORCH_MODE") is None
+
+
+@dataclass
+class UiSession:
+    session_id: str
+    permission: Permission
+    csrf_token: str
+    expires_at: datetime
+
+    @property
+    def pipeline_name(self) -> str | None:
+        if self.permission.pipeline:
+            return self.permission.pipeline.name
+        return None
+
+
+class UiSessionStore:
+    """Stores UI sessions and provides methods for creating, retrieving, and revoking
+    sessions."""
+
+    def __init__(self):
+        self._sessions: dict[str, UiSession] = {}
+        self._lock = Lock()
+
+    def create(self, permission: Permission) -> UiSession:
+        """Create a new UI session for the given permission and return it."""
+
+        session = UiSession(
+            session_id=token_urlsafe(32),
+            permission=permission,
+            csrf_token=token_urlsafe(32),
+            expires_at=datetime.now() + timedelta(seconds=UI_SESSION_TTL_SECONDS),
+        )
+        with self._lock:
+            self._purge_expired_locked()
+            self._sessions[session.session_id] = session
+        return session
+
+    def get(self, session_id: str | None) -> UiSession | None:
+        """Return the UI session for the given session ID, or None if not found."""
+
+        if not session_id:
+            return None
+        with self._lock:
+            self._purge_expired_locked()
+            return self._sessions.get(session_id)
+
+    def revoke(self, session_id: str | None) -> None:
+        """Revoke a UI session by session ID. If the session ID is None, does nothing."""
+
+        if not session_id:
+            return
+        with self._lock:
+            self._sessions.pop(session_id, None)
+
+    def _purge_expired_locked(self) -> None:
+        now = datetime.now()
+        expired = [
+            session_id
+            for session_id, session in self._sessions.items()
+            if session.expires_at <= now
+        ]
+        for session_id in expired:
+            self._sessions.pop(session_id, None)
+
+
+ui_session_store = UiSessionStore()
+
+
+def set_ui_session_cookie(response: Response, session_id: str) -> None:
+    """Set the UI session cookie in the response."""
+
+    # The UI uses an HttpOnly cookie so the browser never has to persist the
+    # original bearer token in script-visible storage.
+    response.set_cookie(
+        key=UI_SESSION_COOKIE_NAME,
+        value=session_id,
+        max_age=UI_SESSION_TTL_SECONDS,
+        path="/",
+        secure=UI_SESSION_COOKIE_SECURE,
+        httponly=True,
+        samesite="strict",
+    )
+
+
+def clear_ui_session_cookie(response: Response) -> None:
+    """Clear the UI session cookie from the response."""
+
+    response.delete_cookie(UI_SESSION_COOKIE_NAME, path="/")
+
+
+def get_ui_session(request: Request) -> UiSession | None:
+    """Retrieve the UI session from the request cookies."""
+
+    return ui_session_store.get(request.cookies.get(UI_SESSION_COOKIE_NAME))
+
+
+def build_ui_session_context(request: Request) -> dict:
+    """Build the UI session context for the current request."""
+
+    session = get_ui_session(request)
+    return {
+        "ui_session_active": session is not None,
+        "ui_session_pipeline_name": session.pipeline_name if session else None,
+        "ui_csrf_token": session.csrf_token if session else None,
+    }
+
+
+def require_ui_session(request: Request) -> UiSession:
+    """Require a valid UI session for the current request."""
+
+    session = get_ui_session(request)
+    if session is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="UI session required",
+        )
+    return session
+
+
+def validate_ui_csrf(request: Request, session: UiSession) -> None:
+    """Validate the UI CSRF token for the current request."""
+
+    # Cookie auth fixes token exposure, but browser requests then need CSRF
+    # protection to stop cross-site state changes.
+    csrf_token = request.headers.get(UI_CSRF_HEADER_NAME)
+    if csrf_token is None or not compare_digest(csrf_token, session.csrf_token):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid CSRF token",
+        )

--- a/src/npg_porch/db/data_access.py
+++ b/src/npg_porch/db/data_access.py
@@ -398,7 +398,14 @@ class AsyncDbAccessor:
         for pipeline, pipeline_tasks in not_done.items():
             if pipeline not in lengths.keys() or len(lengths[pipeline]) < 2:
                 continue  # not enough data for this pipeline
-            cutoff = mean(lengths[pipeline]) + (2 * stdev(lengths[pipeline]))
+
+            # With only two DONE samples, sample stdev can dominate the cutoff and
+            # suppress expected long-running tasks in tests or real low-volume data.
+            done_lengths = lengths[pipeline]
+            cutoff = mean(done_lengths)
+            if len(done_lengths) > 2:
+                cutoff += 2 * stdev(done_lengths)
+
             for task in pipeline_tasks:
                 if (datetime.now() - task.created).total_seconds() > cutoff:
                     long_running.append(task)

--- a/src/npg_porch/endpoints/ui.py
+++ b/src/npg_porch/endpoints/ui.py
@@ -18,11 +18,25 @@
 # this program. If not, see <http://www.gnu.org/licenses/>.
 from datetime import datetime
 from enum import Enum
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse, Response
+from pydantic import BaseModel
+from sqlalchemy.orm.exc import NoResultFound
 from starlette import status
 
+from npg_porch.auth.ui_session import (
+    clear_ui_session_cookie,
+    get_ui_session,
+    require_ui_session,
+    set_ui_session_cookie,
+    ui_session_store,
+    validate_ui_csrf,
+)
+from npg_porch.db.auth import CredentialsValidationException
 from npg_porch.db.connection import get_DbAccessor
-from npg_porch.models import TaskStateEnum
+from npg_porch.db.connection import get_CredentialsValidator
+from npg_porch.models import Task, TaskStateEnum
+from npg_porch.models.permission import PermissionValidationException, RolesEnum
 
 
 class UiStateEnum(str, Enum):
@@ -31,6 +45,10 @@ class UiStateEnum(str, Enum):
 
     ALL = "All"
     NOT_DONE = "NOT DONE"
+
+
+class UiSessionLoginRequest(BaseModel):
+    token: str
 
 
 router = APIRouter(
@@ -84,3 +102,97 @@ async def get_long_running_ui_tasks(
     params = request.query_params.get
     task_list = await db_accessor.get_long_running_tasks()
     return {"draw": params("draw"), "recordsTotal": len(task_list), "data": task_list}
+
+
+@router.post(
+    "/session",
+    summary="Create a browser session for authenticated UI task updates.",
+)
+async def create_ui_session(
+    session_request: UiSessionLoginRequest,
+    request: Request,
+    validator=Depends(get_CredentialsValidator),
+) -> JSONResponse:
+    try:
+        permission = await validator.token2permission(session_request.token)
+    except CredentialsValidationException:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid token")
+
+    # Browser editing is restricted to pipeline-scoped tokens so the UI cannot
+    # silently mint a broader web session from a power-user credential.
+    if permission.role != RolesEnum.REGULAR_USER or permission.pipeline is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="UI task updates require a pipeline token",
+        )
+
+    existing_session = get_ui_session(request)
+    if existing_session:
+        # Keep one active browser session per client to avoid stale CSRF tokens
+        # lingering after a token switch.
+        ui_session_store.revoke(existing_session.session_id)
+
+    session = ui_session_store.create(permission)
+    response = JSONResponse(
+        {
+            "csrf_token": session.csrf_token,
+            "pipeline_name": session.pipeline_name,
+        }
+    )
+    response.headers["Cache-Control"] = "no-store"
+    set_ui_session_cookie(response, session.session_id)
+    return response
+
+
+@router.delete(
+    "/session",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Clear the current browser session for authenticated UI task updates.",
+)
+async def delete_ui_session(request: Request) -> Response:
+    session = get_ui_session(request)
+    if session is not None:
+        validate_ui_csrf(request, session)
+        ui_session_store.revoke(session.session_id)
+
+    response = Response(status_code=status.HTTP_204_NO_CONTENT)
+    response.headers["Cache-Control"] = "no-store"
+    clear_ui_session_cookie(response)
+    return response
+
+
+@router.put(
+    "/tasks",
+    response_model=Task,
+    responses={status.HTTP_200_OK: {"description": "Task was modified"}},
+    summary="Update one task using an authenticated browser session.",
+)
+async def update_ui_task(
+    task: Task,
+    request: Request,
+    db_accessor=Depends(get_DbAccessor),
+) -> Task:
+    # This route mirrors the API update flow but authenticates from the UI
+    # session cookie so the page no longer sends bearer tokens in JS requests.
+    session = require_ui_session(request)
+    validate_ui_csrf(request, session)
+
+    try:
+        session.permission.validate_pipeline(task.pipeline)
+    except PermissionValidationException:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "Given credentials cannot be used for"
+                f" pipeline '{task.pipeline.name}'"
+            ),
+        )
+
+    try:
+        changed_task = await db_accessor.update_task(
+            token_id=session.permission.requestor_id, task=task
+        )
+    except NoResultFound as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+
+    return changed_task

--- a/src/npg_porch/server.py
+++ b/src/npg_porch/server.py
@@ -20,6 +20,7 @@
 from datetime import datetime, timedelta
 from enum import Enum
 from importlib import metadata
+from pathlib import Path
 
 from fastapi import FastAPI, Request, Depends
 from fastapi.responses import (
@@ -27,9 +28,11 @@ from fastapi.responses import (
     HTMLResponse,
     RedirectResponse,
 )
+from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-from jinja2 import Environment, PackageLoader
+from jinja2 import Environment, PackageLoader, select_autoescape
 
+from npg_porch.auth.ui_session import build_ui_session_context
 from npg_porch.db.connection import get_DbAccessor
 from npg_porch.endpoints import pipelines, tasks, ui, versions
 from npg_porch.models import TaskStateEnum
@@ -38,6 +41,24 @@ from npg_porch.models import TaskStateEnum
 # https://fastapi.tiangolo.com/tutorial/metadata
 
 RECENT = datetime.now() - timedelta(days=14)
+STATIC_DIR = Path(__file__).resolve().parent / "static"
+HTML_PATHS_WITH_CSP = {"/", "/long_running", "/recently_failed", "/about"}
+# Lock HTML pages down to the CDN origins we intentionally depend on; the
+# listing page JS/CSS was moved to /static so CSP does not need inline script/style.
+CONTENT_SECURITY_POLICY = "; ".join(
+    [
+        "default-src 'self'",
+        "script-src 'self' https://code.jquery.com https://cdn.datatables.net",
+        "style-src 'self' https://cdn.jsdelivr.net https://cdn.datatables.net",
+        "img-src 'self' data:",
+        "font-src 'self' https://cdn.jsdelivr.net",
+        "connect-src 'self'",
+        "object-src 'none'",
+        "base-uri 'self'",
+        "frame-ancestors 'none'",
+        "form-action 'self'",
+    ]
+)
 
 tags_metadata = [
     {
@@ -59,12 +80,33 @@ app = FastAPI(
     openapi_url="/api/v1/openapi.json",
     openapi_tags=tags_metadata,
 )
+app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 app.include_router(pipelines.router)
 app.include_router(tasks.router)
 app.include_router(ui.router)
 app.include_router(versions.router)
 
-env = Environment(loader=PackageLoader("npg_porch", "templates"))
+
+@app.middleware("http")
+async def add_content_security_policy(request: Request, call_next):
+    response = await call_next(request)
+    content_type = response.headers.get("content-type", "")
+    if (
+        content_type.startswith("text/html")
+        and request.url.path not in {"/docs", "/redoc"}
+    ) or request.url.path in HTML_PATHS_WITH_CSP:
+        response.headers["Content-Security-Policy"] = CONTENT_SECURITY_POLICY
+    return response
+
+# Autoescape is enabled for .j2 templates so database-backed names and other
+# user-controlled values do not get rendered into HTML verbatim.
+env = Environment(
+    loader=PackageLoader("npg_porch", "templates"),
+    autoescape=select_autoescape(
+        enabled_extensions=("html", "htm", "xml", "j2"),
+        default_for_string=True,
+    ),
+)
 templates = Jinja2Templates(env=env)
 
 version = metadata.version("npg_porch")
@@ -120,12 +162,16 @@ async def root(
     request: Request,
     pipeline_name: str = None,
     task_status: ui.UiStateEnum | TaskStateEnum = ui.UiStateEnum.ALL,
+    filter_mode: FilterModeEnum = FilterModeEnum.ALL,
     db_accessor=Depends(get_DbAccessor),
 ) -> Response:
-    mode = FilterModeEnum.ALL
+    mode = filter_mode
     redirect = False
     url = request.url
 
+    if mode == FilterModeEnum.ALL and "filter_mode" in request.query_params.keys():
+        url = url.remove_query_params("filter_mode")
+        redirect = True
     if not pipeline_name and "pipeline_name" in request.query_params.keys():
         url = url.remove_query_params("pipeline_name")
         redirect = True
@@ -144,14 +190,20 @@ async def root(
         if pipeline_name and pipeline_name not in [
             pipeline.name for pipeline in pipeline_list
         ]:
-            return HTMLResponse(
-                f"""
-                <h1> Error 404 </h1>
-                <h3> {pipeline_name} not registered in POrch </h3> 
-                """
+            # The original raw HTML response reflected pipeline_name directly.
+            # Render a template instead so unknown names are escaped consistently.
+            return templates.TemplateResponse(
+                request,
+                "not_found.j2",
+                {
+                    "requested_pipeline": pipeline_name,
+                    "version": version,
+                },
+                status_code=404,
             )
 
     endpoint = _build_endpoint(pipeline_name, task_status, mode)
+    ui_session_context = build_ui_session_context(request)
 
     return templates.TemplateResponse(
         request,
@@ -165,7 +217,9 @@ async def root(
             "pipelines": pipeline_list,
             "states": [state for state in ui.UiStateEnum]
             + [state for state in TaskStateEnum],
+            "task_states": [str(state) for state in TaskStateEnum],
             "version": version,
+            **ui_session_context,
         },
     )
 
@@ -181,6 +235,7 @@ async def long_running(
     db_accessor=Depends(get_DbAccessor),
 ) -> HTMLResponse:
     pipeline_list = await db_accessor.get_recent_pipelines()
+    ui_session_context = build_ui_session_context(request)
     return templates.TemplateResponse(
         request,
         "listing.j2",
@@ -195,7 +250,9 @@ async def long_running(
             "pipelines": pipeline_list,
             "states": [state for state in ui.UiStateEnum]
             + [state for state in TaskStateEnum],
+            "task_states": [str(state) for state in TaskStateEnum],
             "version": version,
+            **ui_session_context,
         },
     )
 
@@ -211,6 +268,7 @@ async def recently_failed(
     db_accessor=Depends(get_DbAccessor),
 ) -> HTMLResponse:
     pipeline_list = await db_accessor.get_recent_pipelines()
+    ui_session_context = build_ui_session_context(request)
     return templates.TemplateResponse(
         request,
         "listing.j2",
@@ -225,7 +283,9 @@ async def recently_failed(
             "pipelines": pipeline_list,
             "states": [state for state in ui.UiStateEnum]
             + [state for state in TaskStateEnum],
+            "task_states": [str(state) for state in TaskStateEnum],
             "version": version,
+            **ui_session_context,
         },
     )
 

--- a/src/npg_porch/static/listing.css
+++ b/src/npg_porch/static/listing.css
@@ -1,0 +1,54 @@
+.control-surface {
+  padding: 0.875rem 1rem;
+  border: 1px solid #dbe3ef;
+  border-radius: 0.75rem;
+  background: #f8fbff;
+}
+
+.primary-action-button {
+  width: 14rem;
+  min-width: 14rem;
+}
+
+.update-toolbar {
+  margin-top: 0.75rem;
+}
+
+.update-toolbar-status {
+  margin-left: auto;
+  min-height: 1.25rem;
+}
+
+.update-toolbar-apply {
+  margin-left: auto;
+}
+
+.status-column,
+#tasks th.status-column,
+#tasks td.status-column {
+  min-width: 11rem;
+  white-space: nowrap;
+}
+
+#tasks td.status-column .task-status-select {
+  min-width: 9rem;
+}
+
+.task-filter-description {
+  min-height: 3rem;
+}
+
+.token-dialog-form {
+  min-width: 22rem;
+}
+
+@media (max-width: 1199.98px) {
+  .update-toolbar-status {
+    width: 100%;
+    margin-left: 0;
+  }
+
+  .update-toolbar-apply {
+    margin-left: 0;
+  }
+}

--- a/src/npg_porch/static/listing.js
+++ b/src/npg_porch/static/listing.js
@@ -1,0 +1,595 @@
+(function() {
+  const pageConfig = document.getElementById('listing_page');
+  if (!pageConfig) {
+    return;
+  }
+
+  function parseJsonDataset(element, key, fallback) {
+    const value = element.dataset[key];
+    if (value === undefined || value === '') {
+      return fallback;
+    }
+    try {
+      return JSON.parse(value);
+    } catch {
+      return fallback;
+    }
+  }
+
+  const taskStateOptions = parseJsonDataset(pageConfig, 'taskStatesJson', []);
+  const endpoint = parseJsonDataset(pageConfig, 'endpointJson', '');
+  const rowStatusClasses = [
+    'table-success',
+    'table-primary',
+    'table-warning',
+    'table-light',
+    'table-danger',
+    'table-secondary',
+    'table-info'
+  ];
+  const pendingChanges = new Map();
+  const rowErrors = new Map();
+  let uiCsrfToken = parseJsonDataset(pageConfig, 'uiCsrfTokenJson', null);
+  let uiSessionPipelineName = parseJsonDataset(
+    pageConfig, 'uiSessionPipelineNameJson', null
+  );
+  let applyInFlight = false;
+
+  function escapeHtml(value) {
+    return String(value)
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&#39;');
+  }
+
+  function renderText(value, type) {
+    if (value === null || value === undefined) {
+      return '';
+    }
+    const text = String(value);
+    // DataTables writes display values as HTML, so escape browser-facing text
+    // here to prevent task data and pipeline names becoming markup.
+    return type === 'display' ? escapeHtml(text) : text;
+  }
+
+  function renderJson(value, type) {
+    if (value === null || value === undefined) {
+      return '';
+    }
+    const text = JSON.stringify(value);
+    // Task input is user-controlled JSON and must be escaped before display
+    // for the same reason as plain-text columns above.
+    return type === 'display' ? escapeHtml(text) : text;
+  }
+
+  function stableStringify(value) {
+    if (value === null || typeof value !== 'object') {
+      return JSON.stringify(value);
+    }
+    if (Array.isArray(value)) {
+      return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+    }
+    const entries = Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`);
+    return `{${entries.join(',')}}`;
+  }
+
+  function buildTaskKey(task) {
+    if (!task || !task.pipeline || !task.task_input) {
+      return null;
+    }
+    return `${task.pipeline.name}::${task.pipeline.version}::${stableStringify(task.task_input)}`;
+  }
+
+  function updateApplyButton() {
+    const applyButton = document.getElementById('apply_state_changes');
+    if (!applyButton) {
+      return;
+    }
+    const count = pendingChanges.size;
+    applyButton.disabled = count === 0 || applyInFlight;
+    applyButton.textContent = `Apply State Changes (${count})`;
+  }
+
+  function updateSessionControls() {
+    const sessionStatus = document.getElementById('ui_session_status');
+    const signInButton = document.getElementById('sign_in_for_updates');
+    const signOutButton = document.getElementById('sign_out_of_updates');
+    const active = Boolean(uiCsrfToken);
+
+    if (sessionStatus) {
+      sessionStatus.textContent = active
+        ? `Update session active for pipeline ${uiSessionPipelineName}.`
+        : 'No update session active.';
+    }
+    if (signInButton) {
+      signInButton.textContent = active ? 'Switch Update Session' : 'Sign In for Updates';
+    }
+    if (signOutButton) {
+      signOutButton.disabled = !active;
+    }
+  }
+
+  function setUpdateResult(message, level) {
+    const resultElement = document.getElementById('update_result');
+    if (!resultElement) {
+      return;
+    }
+    if (!message) {
+      resultElement.className = 'alert d-none py-2 mb-0 mt-3';
+      resultElement.textContent = '';
+      return;
+    }
+    resultElement.className = `alert alert-${level} py-2 mb-0 mt-3`;
+    resultElement.textContent = message;
+  }
+
+  function selectedStatusForRow(row) {
+    const key = buildTaskKey(row);
+    const pending = key ? pendingChanges.get(key) : null;
+    return pending ? pending.status : row.status;
+  }
+
+  function renderStatusEditor(data, type, row) {
+    if (type !== 'display') {
+      return selectedStatusForRow(row);
+    }
+    const key = buildTaskKey(row);
+    const currentStatus = selectedStatusForRow(row);
+    const options = taskStateOptions.map((option) => {
+      const selected = option === currentStatus ? ' selected' : '';
+      return `<option value="${escapeHtml(option)}"${selected}>${escapeHtml(option)}</option>`;
+    }).join('');
+    const hasError = key && rowErrors.has(key);
+    const errorMarkup = hasError
+      ? `<div class="small text-danger mt-1">${escapeHtml(rowErrors.get(key))}</div>`
+      : '';
+    const keyAttribute = key ? ` data-task-key="${escapeHtml(key)}"` : '';
+
+    return (
+      `<div class="status-editor${pendingChanges.has(key) ? ' status-dirty' : ''}">` +
+      `<select class="form-select form-select-sm task-status-select"${keyAttribute}>${options}</select>` +
+      `${errorMarkup}` +
+      `</div>`
+    );
+  }
+
+  const table = new DataTable('#tasks', {
+    ajax: {
+      url: endpoint,
+      dataSrc: function(response) {
+        return (response.data || []).map((row) => {
+          const taskKey = buildTaskKey(row);
+          const pending = taskKey ? pendingChanges.get(taskKey) : null;
+          return {
+            ...row,
+            // Preserve original status from first user edit for stable dirty tracking.
+            original_status: pending ? pending.original_status : row.status
+          };
+        });
+      }
+    },
+    processing: true,
+    columns: [
+      {
+        data: 'pipeline.name',
+        render: function(data, type) {
+          return renderText(data, type);
+        }
+      },
+      {
+        data: 'pipeline.version',
+        render: function(data, type) {
+          return renderText(data, type);
+        }
+      },
+      {
+        data: 'task_input',
+        render: function(data, type) {
+          return renderJson(data, type);
+        }
+      },
+      {
+        data: 'status',
+        className: 'status-column',
+        width: '11rem',
+        render: function(data, type, row) {
+          return renderStatusEditor(data, type, row);
+        }
+      },
+      {
+        data: 'updated',
+        render: function(data, type) {
+          return renderText(data, type);
+        }
+      },
+      {
+        data: 'created',
+        render: function(data, type) {
+          return renderText(data, type);
+        }
+      }
+    ],
+    order: [[4, 'desc' ]],
+    rowCallback: function(row, data) {
+      $(row).removeClass(rowStatusClasses.join(' '));
+      const status = data.status ? data.status.toLowerCase() : '';
+      const statusClassMap = {
+        'done': 'table-success',
+        'running': 'table-primary',
+        'claimed': 'table-warning',
+        'pending': 'table-light',
+        'failed': 'table-danger',
+        'cancelled': 'table-secondary'
+      };
+
+      const bootstrapClass = statusClassMap[status];
+      if (bootstrapClass) {
+        $(row).addClass(bootstrapClass);
+      }
+      const taskKey = buildTaskKey(data);
+      if (taskKey && pendingChanges.has(taskKey)) {
+        $(row).addClass('table-info');
+      }
+    }
+  });
+
+  $('#tasks tbody').on('change', '.task-status-select', function() {
+    const row = $(this).closest('tr');
+    const rowData = table.row(row).data();
+    if (!rowData) {
+      return;
+    }
+    const taskKey = buildTaskKey(rowData);
+    if (!taskKey) {
+      return;
+    }
+
+    rowErrors.delete(taskKey);
+    const selectedStatus = this.value;
+    const existingChange = pendingChanges.get(taskKey);
+    const originalStatus = existingChange
+      ? existingChange.original_status
+      : rowData.original_status;
+    if (selectedStatus === originalStatus) {
+      pendingChanges.delete(taskKey);
+    } else {
+      pendingChanges.set(taskKey, {
+        pipeline: rowData.pipeline,
+        task_input: rowData.task_input,
+        status: selectedStatus,
+        original_status: originalStatus
+      });
+    }
+    updateApplyButton();
+    table.draw(false);
+  });
+
+  const filterMode = document.getElementById('filter_mode');
+  const selectionForm = document.getElementById('selection_form');
+  const pipelineSelection = document.getElementById('pipeline_selection');
+  const stateSelection = document.getElementById('state_selection');
+  const tokenDialog = document.getElementById('token_dialog');
+  const tokenInput = document.getElementById('update_token_input');
+  const signInButton = document.getElementById('sign_in_for_updates');
+  const signOutButton = document.getElementById('sign_out_of_updates');
+  const cancelTokenDialogButton = document.getElementById('cancel_token_dialog');
+  const tokenForm = document.getElementById('token_form');
+  const applyStateChangesButton = document.getElementById('apply_state_changes');
+  const tokenFallback = document.getElementById('token_fallback');
+  const tokenFallbackForm = document.getElementById('token_fallback_form');
+  const tokenFallbackInput = document.getElementById('token_fallback_input');
+  const tokenFallbackCancel = document.getElementById('token_fallback_cancel');
+  let tokenFallbackResolver = null;
+
+  if (tokenForm) {
+    tokenForm.addEventListener('submit', function(event) {
+      event.preventDefault();
+      if (!tokenInput) {
+        tokenDialog.close('cancel');
+        return;
+      }
+      const token = tokenInput.value.trim();
+      if (!token) {
+        tokenInput.setCustomValidity('Token is required.');
+        tokenInput.reportValidity();
+        return;
+      }
+      tokenInput.setCustomValidity('');
+      tokenDialog.dataset.submittedToken = token;
+      tokenDialog.close('submit');
+    });
+  }
+
+  if (cancelTokenDialogButton) {
+    cancelTokenDialogButton.addEventListener('click', function() {
+      if (tokenDialog) {
+        tokenDialog.close('cancel');
+      }
+    });
+  }
+
+  function closeTokenFallback(token) {
+    if (tokenFallback) {
+      tokenFallback.classList.add('d-none');
+    }
+    const resolver = tokenFallbackResolver;
+    tokenFallbackResolver = null;
+    if (resolver) {
+      resolver(token);
+    }
+  }
+
+  function showTokenFallback() {
+    if (!tokenFallback || !tokenFallbackInput) {
+      setUpdateResult(
+        'Unable to prompt for token on this browser. Please use a browser with dialog support.',
+        'danger'
+      );
+      return Promise.resolve(null);
+    }
+    if (tokenFallbackResolver) {
+      tokenFallbackResolver(null);
+      tokenFallbackResolver = null;
+    }
+    tokenFallbackInput.value = '';
+    tokenFallbackInput.setCustomValidity('');
+    tokenFallback.classList.remove('d-none');
+    tokenFallbackInput.focus();
+    return new Promise((resolve) => {
+      tokenFallbackResolver = resolve;
+    });
+  }
+
+  if (tokenFallbackForm) {
+    tokenFallbackForm.addEventListener('submit', function(event) {
+      event.preventDefault();
+      if (!tokenFallbackInput) {
+        closeTokenFallback(null);
+        return;
+      }
+      const token = tokenFallbackInput.value.trim();
+      if (!token) {
+        tokenFallbackInput.setCustomValidity('Token is required.');
+        tokenFallbackInput.reportValidity();
+        return;
+      }
+      tokenFallbackInput.setCustomValidity('');
+      tokenFallbackInput.value = '';
+      closeTokenFallback(token);
+    });
+  }
+
+  if (tokenFallbackCancel) {
+    tokenFallbackCancel.addEventListener('click', function() {
+      closeTokenFallback(null);
+    });
+  }
+
+  function showTokenDialog() {
+    if (!tokenDialog || typeof tokenDialog.showModal !== 'function') {
+      return showTokenFallback();
+    }
+    if (tokenInput) {
+      tokenInput.value = '';
+      tokenInput.setCustomValidity('');
+    }
+    delete tokenDialog.dataset.submittedToken;
+    tokenDialog.showModal();
+    return new Promise((resolve) => {
+      const onClose = () => {
+        tokenDialog.removeEventListener('close', onClose);
+        const submittedToken = tokenDialog.dataset.submittedToken || null;
+        delete tokenDialog.dataset.submittedToken;
+        resolve(tokenDialog.returnValue === 'submit' ? submittedToken : null);
+      };
+      tokenDialog.addEventListener('close', onClose);
+    });
+  }
+
+  async function signInWithToken(token) {
+    try {
+      const response = await fetch('/ui/session', {
+        method: 'POST',
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json'
+        },
+        credentials: 'same-origin',
+        body: JSON.stringify({ token })
+      });
+      if (!response.ok) {
+        setUpdateResult(await parseError(response), 'danger');
+        return false;
+      }
+      const payload = await response.json();
+      uiCsrfToken = payload.csrf_token;
+      uiSessionPipelineName = payload.pipeline_name;
+      updateSessionControls();
+      setUpdateResult('Update session created.', 'info');
+      return true;
+    } catch {
+      setUpdateResult('Network error while creating update session.', 'danger');
+      return false;
+    }
+  }
+
+  async function requestUiSession() {
+    if (uiCsrfToken) {
+      return true;
+    }
+    const token = await showTokenDialog();
+    if (!token) {
+      setUpdateResult('Task updates cancelled: no token provided.', 'warning');
+      return false;
+    }
+    return signInWithToken(token);
+  }
+
+  if (signInButton) {
+    signInButton.addEventListener('click', async function() {
+      const token = await showTokenDialog();
+      if (token) {
+        await signInWithToken(token);
+      }
+    });
+  }
+
+  if (signOutButton) {
+    signOutButton.addEventListener('click', async function() {
+      if (!uiCsrfToken) {
+        return;
+      }
+      try {
+        const response = await fetch('/ui/session', {
+          method: 'DELETE',
+          headers: {
+            'X-CSRF-Token': uiCsrfToken
+          },
+          credentials: 'same-origin'
+        });
+        if (!response.ok) {
+          setUpdateResult(await parseError(response), 'danger');
+          return;
+        }
+        uiCsrfToken = null;
+        uiSessionPipelineName = null;
+        updateSessionControls();
+        setUpdateResult('Update session cleared.', 'info');
+      } catch {
+        setUpdateResult('Network error while clearing update session.', 'danger');
+      }
+    });
+  }
+
+  async function parseError(response) {
+    let payload = null;
+    try {
+      payload = await response.json();
+    } catch {
+      payload = null;
+    }
+    if (payload && payload.detail) {
+      return payload.detail;
+    }
+    return `Request failed with status ${response.status}`;
+  }
+
+  async function applyPendingChanges() {
+    if (pendingChanges.size === 0) {
+      setUpdateResult('No changes to apply.', 'warning');
+      return;
+    }
+    const sessionReady = await requestUiSession();
+    if (!sessionReady || !uiCsrfToken) {
+      return;
+    }
+
+    applyInFlight = true;
+    setUpdateResult('', 'info');
+    updateApplyButton();
+    rowErrors.clear();
+
+    const updates = Array.from(pendingChanges.entries());
+    const responses = await Promise.all(
+      updates.map(async ([taskKey, payload]) => {
+        try {
+          const response = await fetch('/ui/tasks', {
+            method: 'PUT',
+            headers: {
+              'Accept': 'application/json',
+              'Content-Type': 'application/json',
+              'X-CSRF-Token': uiCsrfToken
+            },
+            credentials: 'same-origin',
+            body: JSON.stringify(payload)
+          });
+          if (response.ok) {
+            return { taskKey, ok: true };
+          }
+          return { taskKey, ok: false, error: await parseError(response) };
+        } catch {
+          return { taskKey, ok: false, error: 'Network error while updating task' };
+        }
+      })
+    );
+
+    let updated = 0;
+    let failed = 0;
+    for (const result of responses) {
+      if (result.ok) {
+        pendingChanges.delete(result.taskKey);
+        rowErrors.delete(result.taskKey);
+        updated += 1;
+      } else {
+        rowErrors.set(result.taskKey, result.error);
+        failed += 1;
+      }
+    }
+
+    applyInFlight = false;
+    updateApplyButton();
+    table.ajax.reload(null, false);
+    setUpdateResult(
+      `${updated} updated, ${failed} failed.`,
+      failed === 0 ? 'success' : 'warning'
+    );
+  }
+
+  if (applyStateChangesButton) {
+    applyStateChangesButton.addEventListener('click', applyPendingChanges);
+  }
+
+  function resetStateSelection() {
+    if (!stateSelection) {
+      return;
+    }
+    const allOption = Array.from(stateSelection.options).find(
+      (option) => option.value === 'All'
+    );
+    if (allOption) {
+      stateSelection.value = allOption.value;
+      return;
+    }
+    const emptyOption = Array.from(stateSelection.options).find(
+      (option) => option.value === ''
+    );
+    if (emptyOption) {
+      stateSelection.value = '';
+      return;
+    }
+    stateSelection.selectedIndex = 0;
+  }
+
+  function syncFilterMode() {
+    if (!filterMode || !pipelineSelection || !stateSelection) {
+      return;
+    }
+    const isAll = filterMode.value === 'all';
+    pipelineSelection.disabled = !isAll;
+    stateSelection.disabled = !isAll;
+    if (!isAll) {
+      pipelineSelection.value = '';
+      resetStateSelection();
+    }
+    if (selectionForm) {
+      if (filterMode.value === 'long_running') {
+        selectionForm.action = '/long_running';
+      } else if (filterMode.value === 'recently_failed') {
+        selectionForm.action = '/recently_failed';
+      } else {
+        selectionForm.action = '/';
+      }
+    }
+  }
+
+  if (filterMode) {
+    filterMode.addEventListener('change', syncFilterMode);
+    syncFilterMode();
+  }
+  updateSessionControls();
+  updateApplyButton();
+})();

--- a/src/npg_porch/templates/listing.j2
+++ b/src/npg_porch/templates/listing.j2
@@ -4,21 +4,43 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Porch Tasks</title>
-    <link rel="stylesheet" href="https://cdn.datatables.net/2.3.2/css/dataTables.dataTables.min.css">
-    <link rel="stylesheet" href="https://cdn.datatables.net/2.3.2/css/dataTables.bootstrap5.css">
+    <link rel="stylesheet"
+          href="https://cdn.datatables.net/2.3.2/css/dataTables.dataTables.min.css"
+          integrity="sha384-gC2LYLqCExndkNE9hTLhmEXvk8ZgIf42nRengHFbC9uaws2Ho0TW+ENGe4w15AHy"
+          crossorigin="anonymous">
+    <link rel="stylesheet"
+          href="https://cdn.datatables.net/2.3.2/css/dataTables.bootstrap5.css"
+          integrity="sha384-bpCK7rktevnwex1yLPochNMmcEoKt7YD+UmHEwHuyMUIZissaXuQkMeNKybbm6/v"
+          crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
           integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
           crossorigin="anonymous">
-    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="https://cdn.datatables.net/2.3.2/js/dataTables.js"></script>
+    <link rel="stylesheet" href="/static/listing.css">
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"
+            integrity="sha384-1H217gwSVyLSIfaLxHbE7dRb3v4mYCKbpQvzx0cegeju1MVsGrX5xXxAvs/HgeFs"
+            crossorigin="anonymous"></script>
+    <script src="https://cdn.datatables.net/2.3.2/js/dataTables.js"
+            integrity="sha384-YDIK5P2Wq/2RyB+U8Zt970p1L/fEftZwbF3e22rV/bPMW+m8z+JjycMAr96s7LAz"
+            crossorigin="anonymous"></script>
   </head>
   <body>
     {% set filter_mode = filter_mode if filter_mode else "all" %}
-    <div class="container-fluid mb-5">
+    <div id="listing_page"
+         class="container-fluid mb-5"
+         {# Page state lives in data-* attributes so the UI can boot from a
+            static first-party script under CSP instead of inline JavaScript.
+            The HTML Standard defines data-* as custom element data and says
+            user agents must not derive implementation behavior from it, so
+            the browser does not execute these values as code:
+            https://html.spec.whatwg.org/multipage/dom.html#embedding-custom-non-visible-data-with-the-data-%2a-attributes #}
+         data-endpoint-json="{{ endpoint | tojson | forceescape }}"
+         data-task-states-json="{{ task_states | tojson | forceescape }}"
+         data-ui-csrf-token-json="{{ ui_csrf_token | tojson | forceescape }}"
+         data-ui-session-pipeline-name-json="{{ ui_session_pipeline_name | tojson | forceescape }}">
       <div class="row mt-4 mb-4">
         <div class="col">
           <h3 class="text-start mb-0">Porch Tasks - {{ filter_heading if filter_heading else "All" }}</h3>
-          <p class="text-muted mb-1" style="min-height: 3rem;">
+          <p class="text-muted mb-1 task-filter-description">
             {% if filter_mode == "long_running" %}
               Long running tasks have existed for two standard deviations longer than the mean length of tasks in their pipeline.
             {% elif filter_mode == "recently_failed" %}
@@ -30,42 +52,53 @@
 
       <div class="row mt-3 mb-4">
         <div class="col">
-          <form method="get" action="/" id="selection_form" class="row g-3 align-items-end">
-            <div class="col-lg-3 col-md-6">
-              <label for="filter_mode" class="form-label text-start">Filter Mode:</label>
-              <select class="form-select" id="filter_mode">
-                <option value="all" {{ "selected" if filter_mode == "all" }}>All</option>
-                <option value="long_running" {{ "selected" if filter_mode == "long_running" }}>Long Running</option>
-                <option value="recently_failed" {{ "selected" if filter_mode == "recently_failed" }}>Recently Failed</option>
-              </select>
+          <section class="control-surface">
+            <form method="get" action="/" id="selection_form" class="row g-3 align-items-end">
+              <div class="col-lg-3 col-md-6">
+                <label for="filter_mode" class="form-label text-start">Filter Mode:</label>
+                <select class="form-select" name="filter_mode" id="filter_mode">
+                  <option value="all" {{ "selected" if filter_mode == "all" }}>All</option>
+                  <option value="long_running" {{ "selected" if filter_mode == "long_running" }}>Long Running</option>
+                  <option value="recently_failed" {{ "selected" if filter_mode == "recently_failed" }}>Recently Failed</option>
+                </select>
+              </div>
+              <div class="col-lg-4 col-md-6">
+                <label for="pipeline_selection" class="form-label text-start">Pipeline Selection:</label>
+                <select class="form-select" name="pipeline_name" id="pipeline_selection" {{ "disabled" if filter_mode != "all" }}>
+                  <option disabled>--Pipeline Selection--</option>
+                  <option {{ "selected" if not pipeline_name }} value="">All</option>
+                  {% for pipeline in pipelines %}
+                    <option {{ "selected" if pipeline_name == pipeline.name }} value="{{ pipeline.name }}">{{ pipeline.name }}</option>
+                  {% endfor %}
+                </select>
+              </div>
+              <div class="col-lg-3 col-md-6">
+                <label for="state_selection" class="form-label text-start">Task Status Selection:</label>
+                <select class="form-select" name="task_status" id="state_selection" {{ "disabled" if filter_mode != "all" }}>
+                  <option disabled>--Task Status Selection--</option>
+                  {% for state in states %}
+                    <option {{ "selected" if task_status == state }} value="{{ state }}">{{ state }}</option>
+                  {% endfor %}
+                </select>
+              </div>
+              <div class="col-lg-2 col-md-6 d-flex justify-content-lg-end justify-content-md-start">
+                <button type="submit" class="btn btn-primary primary-action-button">Apply Filters</button>
+              </div>
+            </form>
+            <div class="update-toolbar">
+              <div class="d-flex flex-wrap gap-2 align-items-center">
+                <button type="button" class="btn btn-outline-primary" id="sign_in_for_updates">Sign In for Updates</button>
+                <button type="button" class="btn btn-outline-secondary" id="sign_out_of_updates" disabled>Sign Out</button>
+                <div id="ui_session_status" class="small text-muted update-toolbar-status"></div>
+                <button type="button" class="btn btn-success primary-action-button update-toolbar-apply" id="apply_state_changes" disabled>Apply State Changes (0)</button>
+              </div>
+              <div id="update_result" class="alert d-none py-2 mb-0 mt-3" role="alert"></div>
             </div>
-            <div class="col-lg-4 col-md-6">
-              <label for="pipeline_selection" class="form-label text-start">Pipeline Selection:</label>
-              <select class="form-select" name="pipeline_name" id="pipeline_selection" {{ "disabled" if filter_mode != "all" }}>
-                <option disabled>--Pipeline Selection--</option>
-                <option {{ "selected" if not pipeline_name }} value="">All</option>
-                {% for pipeline in pipelines %}
-                  <option {{ "selected" if pipeline_name == pipeline.name }} value="{{ pipeline.name }}">{{ pipeline.name }}</option>
-                {% endfor %}
-              </select>
-            </div>
-            <div class="col-lg-3 col-md-6">
-              <label for="state_selection" class="form-label text-start">Task Status Selection:</label>
-              <select class="form-select" name="task_status" id="state_selection" {{ "disabled" if filter_mode != "all" }}>
-                <option disabled>--Task Status Selection--</option>
-                {% for state in states %}
-                  <option {{ "selected" if task_status == state }} value="{{ state }}">{{ state }}</option>
-                {% endfor %}
-              </select>
-            </div>
-            <div class="col-lg-2 col-md-6 d-grid">
-              <button type="submit" class="btn btn-primary">Apply</button>
-            </div>
-          </form>
+          </section>
         </div>
       </div>
 
-      <div class="row mt-4">
+      <div class="row">
         <div class="col">
           <div class="table-responsive mb-4">
             <table class="table table-bordered border-primary" id="tasks">
@@ -74,7 +107,7 @@
                   <th scope="col" class="text-start">Pipeline Name</th>
                   <th scope="col" class="text-start">Pipeline Version</th>
                   <th scope="col" class="text-start">Task Input</th>
-                  <th scope="col" class="text-start">Status</th>
+                  <th scope="col" class="text-start status-column">Status</th>
                   <th scope="col" class="text-start">Status Date</th>
                   <th scope="col" class="text-start">Date Created</th>
                 </tr>
@@ -84,74 +117,34 @@
         </div>
       </div>
     </div>
-    <script>
-      new DataTable('#tasks', {
-        ajax: '{{ endpoint }}',
-        processing: true,
-        columns: [
-          { data: 'pipeline.name' },
-          { data: 'pipeline.version' },
-          { data: 'task_input',
-            render: function(data, type, row) {
-              return JSON.stringify(data).replaceAll(",", ", ");
-            }
-          },
-          { data: 'status' },
-          { data: 'updated' },
-          { data: 'created' }
-        ],
-        order: [[4, 'desc' ]],
-        rowCallback: function(row, data) {
-          const status = data.status.toLowerCase();
-          // Map task statuses to Bootstrap contextual table classes
-          const statusClassMap = {
-            'done': 'table-success',      // Green - successful completion
-            'running': 'table-primary',   // Blue - active/current state
-            'claimed': 'table-warning',   // Yellow - caution/in-progress
-            'pending': 'table-light',     // Light gray - neutral state
-            'failed': 'table-danger',     // Red - error/failure
-            'cancelled': 'table-secondary' // Gray - inactive/cancelled
-          };
 
-          const bootstrapClass = statusClassMap[status];
-          if (bootstrapClass) {
-            $(row).addClass(bootstrapClass);
-          }
-        }
-      })
-
-      const filterMode = document.getElementById('filter_mode');
-      const selectionForm = document.getElementById('selection_form');
-      const pipelineSelection = document.getElementById('pipeline_selection');
-      const stateSelection = document.getElementById('state_selection');
-
-      function syncFilterMode() {
-        if (!filterMode || !pipelineSelection || !stateSelection) {
-          return;
-        }
-        const isAll = filterMode.value === 'all';
-        pipelineSelection.disabled = !isAll;
-        stateSelection.disabled = !isAll;
-        if (!isAll) {
-          pipelineSelection.value = '';
-          stateSelection.value = 'All';
-        }
-        if (selectionForm) {
-          if (filterMode.value === 'long_running') {
-            selectionForm.action = '/long_running';
-          } else if (filterMode.value === 'recently_failed') {
-            selectionForm.action = '/recently_failed';
-          } else {
-            selectionForm.action = '/';
-          }
-        }
-      }
-
-      if (filterMode) {
-        filterMode.addEventListener('change', syncFilterMode);
-        syncFilterMode();
-      }
-    </script>
+    <dialog id="token_dialog">
+      <form method="dialog" id="token_form" class="d-flex flex-column gap-3 token-dialog-form">
+        <h5 class="mb-0">Sign In for Updates</h5>
+        <label for="update_token_input" class="form-label mb-0">
+          Enter a pipeline token to create a browser update session
+        </label>
+        <input id="update_token_input" type="password" class="form-control" required autocomplete="off">
+        <div class="d-flex justify-content-end gap-2">
+          <button type="button" class="btn btn-outline-secondary" id="cancel_token_dialog">Cancel</button>
+          <button type="submit" class="btn btn-primary">Sign In</button>
+        </div>
+      </form>
+    </dialog>
+    <div id="token_fallback" class="card p-3 mb-3 d-none">
+      <form id="token_fallback_form" class="d-flex flex-column gap-3">
+        <h5 class="mb-0">Sign In for Updates</h5>
+        <label for="token_fallback_input" class="form-label mb-0">
+          Enter a pipeline token to create a browser update session
+        </label>
+        <input id="token_fallback_input" type="password" class="form-control" required autocomplete="off">
+        <div class="d-flex justify-content-end gap-2">
+          <button type="button" class="btn btn-outline-secondary" id="token_fallback_cancel">Cancel</button>
+          <button type="submit" class="btn btn-primary">Sign In</button>
+        </div>
+      </form>
+    </div>
+    <script src="/static/listing.js"></script>
 
     <footer class="mt-5 py-3 border-top">
       <div class="container">

--- a/src/npg_porch/templates/not_found.j2
+++ b/src/npg_porch/templates/not_found.j2
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Not Found</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+          rel="stylesheet"
+          integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+          crossorigin="anonymous">
+  </head>
+  <body>
+    <div class="container py-5">
+      <div class="row justify-content-center">
+        <div class="col-lg-8">
+          <div class="card border-danger">
+            <div class="card-body">
+              <h1 class="h3 text-danger">Error 404</h1>
+              <p class="mb-0">
+                Pipeline <code>{{ requested_pipeline }}</code> is not registered in POrch.
+              </p>
+            </div>
+          </div>
+          <div class="mt-3">
+            <a href="/" class="btn btn-primary">Back to task list</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/tests/task_route_test.py
+++ b/tests/task_route_test.py
@@ -62,6 +62,11 @@ def test_task_update(async_minimum, fastapi_testclient):
     task = fastapi_testclient.get("/tasks", headers=headers4ptest_one).json()[0]
     assert task["status"] == TaskStateEnum.PENDING.value
 
+    unauthenticated = fastapi_testclient.put(
+        "/tasks", json=task, follow_redirects=True
+    )
+    assert unauthenticated.status_code == status.HTTP_401_UNAUTHORIZED
+
     task["status"] = TaskStateEnum.RUNNING
     response = fastapi_testclient.put(
         "/tasks", json=task, follow_redirects=True, headers=headers4ptest_one
@@ -95,6 +100,74 @@ def test_task_update(async_minimum, fastapi_testclient):
         headers=headers4ptest_one,
     )
     assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_task_update_mixed_outcomes(async_minimum, fastapi_testclient):
+    # Confirms task updates are independent in a mixed-outcome workflow: a valid
+    # update must be persisted even if a later update in the same user action
+    # fails validation, and the failed update must leave its target task
+    # unchanged.
+    #
+    # This is important because the web UI allows a user to update several tasks in one
+    # batch-like workflow (although we haven't gone to the length of creating a new
+    # batch-like endpoint and are just using the existing endpoint repeatedly).
+    tasks = fastapi_testclient.get(
+        "/tasks?pipeline_name=ptest one", headers=headers4ptest_one
+    ).json()
+    assert len(tasks) == 2, (
+        "The fixture should provide two tasks in ptest one for the mixed-outcome update scenario"
+    )
+
+    to_update = tasks[0]
+    to_fail = tasks[1]
+
+    to_update["status"] = TaskStateEnum.RUNNING
+    success_response = fastapi_testclient.put(
+        "/tasks", json=to_update, follow_redirects=True, headers=headers4ptest_one
+    )
+    assert success_response.status_code == status.HTTP_200_OK, (
+        "Updating the first task with a valid payload should succeed"
+    )
+
+    # Change the identifying task_input as well as the status so the server can
+    # no longer match this request to an existing task to update.
+    invalid_signature_payload = dict(to_fail)
+    invalid_signature_payload["status"] = TaskStateEnum.RUNNING
+    invalid_signature_payload["task_input"] = {"this": "does not match existing task"}
+    failed_response = fastapi_testclient.put(
+        "/tasks",
+        json=invalid_signature_payload,
+        follow_redirects=True,
+        headers=headers4ptest_one,
+    )
+    assert failed_response.status_code == status.HTTP_404_NOT_FOUND, (
+        "Updating the second task with a mismatched signature should fail"
+    )
+    assert failed_response.json() == {"detail": "Task to be modified could not be found"}, (
+        "A failed update should report that the original task could not be located"
+    )
+
+    # Re-query by status to prove the first update stuck and the second task was
+    # not moved despite the failed request.
+    running_tasks = fastapi_testclient.get(
+        "/tasks?pipeline_name=ptest one&status=RUNNING", headers=headers4ptest_one
+    ).json()
+    assert len(running_tasks) == 1, (
+        "Only the successfully updated task should be moved into RUNNING"
+    )
+    assert running_tasks[0]["task_input"] == to_update["task_input"], (
+        "The RUNNING task should be the one that was updated successfully"
+    )
+
+    pending_tasks = fastapi_testclient.get(
+        "/tasks?pipeline_name=ptest one&status=PENDING", headers=headers4ptest_one
+    ).json()
+    assert len(pending_tasks) == 1, (
+        "The failed update should leave the other task in PENDING"
+    )
+    assert pending_tasks[0]["task_input"] == to_fail["task_input"], (
+        "The still-pending task should be the one whose update failed"
+    )
 
 
 def test_task_claim(async_minimum, async_tasks, fastapi_testclient):

--- a/tests/ui_route_test.py
+++ b/tests/ui_route_test.py
@@ -1,13 +1,24 @@
 from datetime import datetime, timedelta
+import html
+import json
+import re
 
 import pytest
 from fastapi.testclient import TestClient
+from starlette import status
 
 from npg_porch.endpoints import ui
 from npg_porch.server import app
 from npg_porch.models import Pipeline, Task, TaskStateEnum
 
 client = TestClient(app)
+ptest_one_token = "cac0533d5599489d9a3d998028a79fe8"
+
+
+def _extract_page_json_attr(page: str, attr_name: str):
+    match = re.search(rf'{attr_name}="([^"]+)"', page)
+    assert match, f"{attr_name} should be rendered into page config"
+    return json.loads(html.unescape(match.group(1)))
 
 
 @pytest.mark.asyncio
@@ -97,3 +108,225 @@ async def test_get_long_running_ui_tasks(db_accessor):
     response = client.get("/ui/long_running")
 
     assert response.json()["recordsTotal"] == 2, "Two long running tasks"
+
+
+def test_listing_page_state_editing_controls(async_minimum, fastapi_testclient):
+    # Verifies the listing pages render the edit-state UI shell and boot config needed by the static page script.
+    expected_states = [state.value for state in TaskStateEnum]
+
+    for path in ["/", "/long_running", "/recently_failed"]:
+        response = fastapi_testclient.get(path, follow_redirects=True)
+        assert response.status_code == 200, f"{path} should render successfully"
+        page = response.text
+
+        assert "content-security-policy" in response.headers, (
+            f"{path} should return a CSP header for the listing page"
+        )
+        assert "script-src 'self' https://code.jquery.com https://cdn.datatables.net" in (
+            response.headers["content-security-policy"]
+        ), f"{path} should allow the expected first-party and CDN scripts"
+        assert 'name="filter_mode"' in page, f"{path} should render the filter mode control"
+        assert 'id="apply_state_changes"' in page, (
+            f"{path} should render the task state apply button"
+        )
+        assert 'id="sign_in_for_updates"' in page, (
+            f"{path} should render the sign-in control for update sessions"
+        )
+        assert 'id="sign_out_of_updates"' in page, (
+            f"{path} should render the sign-out control for update sessions"
+        )
+        assert 'id="ui_session_status"' in page, (
+            f"{path} should render the session status text placeholder"
+        )
+        assert 'id="token_dialog"' in page, f"{path} should render the token dialog"
+        assert 'id="token_fallback"' in page, (
+            f"{path} should render the non-dialog token fallback form"
+        )
+        assert 'id="listing_page"' in page, (
+            f"{path} should render the root page element for bootstrapping"
+        )
+        assert 'href="/static/listing.css"' in page, (
+            f"{path} should load the first-party listing stylesheet"
+        )
+        assert 'src="/static/listing.js"' in page, (
+            f"{path} should load the first-party listing script"
+        )
+        assert 'class="text-start status-column">Status<' in page, (
+            f"{path} should render the editable status column header"
+        )
+        assert _extract_page_json_attr(page, "data-task-states-json") == expected_states, (
+            f"{path} should expose the task state options to the page script"
+        )
+        assert _extract_page_json_attr(page, "data-endpoint-json").startswith("/ui/"), (
+            f"{path} should expose a UI data endpoint to the page script"
+        )
+        assert _extract_page_json_attr(page, "data-ui-csrf-token-json") is None, (
+            f"{path} should start with no active UI session CSRF token"
+        )
+        assert _extract_page_json_attr(page, "data-ui-session-pipeline-name-json") is None, (
+            f"{path} should start with no active UI session pipeline name"
+        )
+
+
+def test_listing_page_includes_active_ui_session(async_minimum, fastapi_testclient):
+    login = fastapi_testclient.post("/ui/session", json={"token": ptest_one_token})
+    assert login.status_code == 200, (
+        "Creating a UI session with a valid token should succeed"
+    )
+
+    response = fastapi_testclient.get("/", follow_redirects=True)
+    assert response.status_code == 200, (
+        "The listing page should still render after creating a UI session"
+    )
+    page = response.text
+
+    assert _extract_page_json_attr(page, "data-ui-csrf-token-json"), (
+        "An active UI session should expose a CSRF token to the page script"
+    )
+    assert _extract_page_json_attr(page, "data-ui-session-pipeline-name-json") == "ptest one", (
+        "An active UI session should expose the session pipeline name to the page script"
+    )
+
+
+def test_ui_session_rejects_invalid_token(fastapi_testclient):
+    login = fastapi_testclient.post("/ui/session", json={"token": "not-a-real-token"})
+
+    assert login.status_code == status.HTTP_403_FORBIDDEN, (
+        "Creating a UI session with an invalid token should be rejected"
+    )
+    assert login.json() == {"detail": "Invalid token"}, (
+        "An invalid UI session token should return the expected error payload"
+    )
+    assert login.cookies.get("npg_porch_ui_session") is None, (
+        "Rejecting an invalid token should not create a UI session cookie"
+    )
+
+
+@pytest.mark.asyncio
+async def test_listing_page_escapes_pipeline_names(db_accessor):
+    pipeline = Pipeline(
+        name='evil<script>alert("xss")</script>',
+        uri="file://test.pipeline",
+        version="1.0",
+    )
+    await db_accessor.create_pipeline(pipeline)
+
+    response = client.get("/", follow_redirects=True)
+    assert response.status_code == 200, (
+        "The listing page should render even when a pipeline name contains HTML"
+    )
+    page = response.text
+
+    assert 'evil<script>alert("xss")</script>' not in page, (
+        "Pipeline names should not be rendered as raw HTML in the listing page"
+    )
+    assert "evil&lt;script&gt;alert" in page, (
+        "Pipeline names should be HTML-escaped in the listing page"
+    )
+
+
+def test_ui_session_login_logout_and_task_update(async_minimum, fastapi_testclient):
+    task = fastapi_testclient.get("/tasks").json()[0]
+    task["status"] = TaskStateEnum.RUNNING
+
+    unauthenticated = fastapi_testclient.put("/ui/tasks", json=task)
+    assert unauthenticated.status_code == status.HTTP_401_UNAUTHORIZED, (
+        "Updating tasks through the UI route should require an authenticated UI session"
+    )
+
+    login = fastapi_testclient.post("/ui/session", json={"token": ptest_one_token})
+    assert login.status_code == status.HTTP_200_OK, (
+        "Creating a UI session with a valid token should succeed"
+    )
+    payload = login.json()
+    assert payload["pipeline_name"] == "ptest one", (
+        "The UI session response should identify the pipeline tied to the token"
+    )
+    csrf_token = payload["csrf_token"]
+    assert csrf_token, "The UI session response should include a CSRF token"
+    session_cookie = login.cookies.get("npg_porch_ui_session")
+    assert session_cookie, "Creating a UI session should set the UI session cookie"
+    set_cookie_header = login.headers["set-cookie"].lower()
+    assert "httponly" in set_cookie_header, (
+        "The UI session cookie should be marked HttpOnly"
+    )
+    assert "samesite=strict" in set_cookie_header, (
+        "The UI session cookie should use SameSite=Strict"
+    )
+
+    missing_csrf = fastapi_testclient.put("/ui/tasks", json=task)
+    assert missing_csrf.status_code == status.HTTP_403_FORBIDDEN, (
+        "The UI task update route should reject requests that omit the CSRF token"
+    )
+    assert missing_csrf.json() == {"detail": "Invalid CSRF token"}, (
+        "Requests missing the CSRF token should fail with the expected error message"
+    )
+
+    updated = fastapi_testclient.put(
+        "/ui/tasks", json=task, headers={"X-CSRF-Token": csrf_token}
+    )
+    assert updated.status_code == status.HTTP_200_OK, (
+        "The UI task update route should accept authenticated requests with a valid CSRF token"
+    )
+    assert updated.json()["status"] == TaskStateEnum.RUNNING, (
+        "The UI task update route should persist the requested task status change"
+    )
+
+    logout = fastapi_testclient.delete(
+        "/ui/session", headers={"X-CSRF-Token": csrf_token}
+    )
+    assert logout.status_code == status.HTTP_204_NO_CONTENT, (
+        "Deleting the UI session with a valid CSRF token should succeed"
+    )
+
+    after_logout = fastapi_testclient.put(
+        "/ui/tasks", json=task, headers={"X-CSRF-Token": csrf_token}
+    )
+    assert after_logout.status_code == status.HTTP_401_UNAUTHORIZED, (
+        "Logging out should invalidate the UI session for subsequent task updates"
+    )
+
+
+def test_root_route_escapes_unknown_pipeline_name(fastapi_testclient):
+    response = fastapi_testclient.get(
+        "/?pipeline_name=%3Cscript%3Ealert(1)%3C%2Fscript%3E",
+        follow_redirects=True,
+    )
+    assert response.status_code == 404, (
+        "Requesting an unknown pipeline should still return a 404 response"
+    )
+    assert "<script>alert(1)</script>" not in response.text, (
+        "The unknown-pipeline page should not render the raw pipeline name as HTML"
+    )
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in response.text, (
+        "The unknown-pipeline page should HTML-escape the requested pipeline name"
+    )
+
+
+def test_root_route_honours_filter_mode_query(async_past_tasks, fastapi_testclient):
+    # Verifies filter_mode query parameters select the expected backing UI endpoint and page heading.
+    long_running = fastapi_testclient.get(
+        "/?filter_mode=long_running", follow_redirects=True
+    )
+    assert long_running.status_code == 200, (
+        "The long_running filter mode should render the listing page"
+    )
+    assert "/ui/long_running" in long_running.text, (
+        "The long_running filter mode should target the long-running UI endpoint"
+    )
+    assert "Long Running" in long_running.text, (
+        "The long_running filter mode should update the page heading"
+    )
+
+    recently_failed = fastapi_testclient.get(
+        "/?filter_mode=recently_failed", follow_redirects=True
+    )
+    assert recently_failed.status_code == 200, (
+        "The recently_failed filter mode should render the listing page"
+    )
+    assert "/ui/tasks/All/FAILED/" in recently_failed.text, (
+        "The recently_failed filter mode should target the failed-task UI endpoint"
+    )
+    assert "Recently Failed" in recently_failed.text, (
+        "The recently_failed filter mode should update the page heading"
+    )


### PR DESCRIPTION
This feature allows users of the web UI who have access to a pipeline token to edit the state of their tasks. This requires that a pipeline token be provided to the web UI to start a session.

<img width="1618" height="887" alt="porch1" src="https://github.com/user-attachments/assets/f8b1bd41-9795-41f2-90ff-fbda7270e991" />
<img width="1607" height="880" alt="porch2" src="https://github.com/user-attachments/assets/00ecf4d6-91b7-4df0-a176-e68d102ebbd2" />
<img width="1600" height="916" alt="porch3" src="https://github.com/user-attachments/assets/01507775-90fd-46ed-9165-e8eff3a7f294" />
